### PR TITLE
ブログカード用の情報を取得する際、ブラウザと同様の HTTP ヘッダーを設定するように変更

### DIFF
--- a/lib/open-graph.php
+++ b/lib/open-graph.php
@@ -63,6 +63,12 @@ class OpenGraphGetter implements Iterator
         $args = array(
           //'sslverify' => false,
           //'redirection' => 10,
+          'headers' => [
+            'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+            'Accept-Encoding' => 'gzip, deflate, br',
+            'Accept-Language' => 'ja,ja-JP;q=0.9,und;q=0.8,en;q=0.7,zh-CN;q=0.6,zh;q=0.5',
+            'Cache-Control' => 'no-cache',
+          ],
           'cocoon' => true,
           'user-agent' => $_SERVER['HTTP_USER_AGENT'],
         );


### PR DESCRIPTION
いつも Cocoon テーマを使わせて頂いています。
先日 https://github.com/xserver-inc/cocoon/pull/60 をマージしていただきましたが、今回もブログカード周りの変更になります。

具体的には、ブログカード用の情報を外部から取得する際、ブラウザと同様の HTTP ヘッダーを設定するように変更しました。
半分偽装みたいなものですが、特に Accept-Language に関して、何か値をセットしておかないと正しく HTTP リクエストが完了しない URL がありました。
当然情報が取得できなければブログカードには URL しか表示されなくなってしまうため、見た目がよくありません。

楽天アフィリエイトのリンクがその例で、2回 302 リダイレクトを挟んだのちに本ページにたどり着くような仕組みになっていますが、Accept-Language が設定されていないとリダイレクトまでに 10 秒以上掛かってしまい、`wp_remote_get()` のデフォルトのタイムアウト値である 5 秒を超過して取得に失敗してしまっていました。
おそらく、サイト側が Accept-Language がセットされていないリクエストを想定していないものと思われます。

そこで Accept-Language を設定したところ、正しくブログカード用の情報を取得することができました。
それ以外のヘッダーに関しても、ブラウザの挙動を再現すればブラウザでアクセスした際と同じような HTML が取得できると考えられる事から、ブラウザと同様の値に設定してあります。