### PR TITLE
404ページ・カテゴリーページ・タグページのアイキャッチ画像から loading=lazy を削除

### DIFF
--- a/404.php
+++ b/404.php
@@ -12,9 +12,9 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
   <!--ループ開始-->
   <h1 class="entry-title"><?php echo get_404_page_title(); ?></h1>
   <?php if ( get_404_image_url() ): ?>
-    <img class="not-found" src="<?php echo get_404_image_url(); ?>" alt="404 Not Found" loading="lazy" decoding="async" />
+    <img class="not-found" src="<?php echo get_404_image_url(); ?>" alt="404 Not Found" decoding="async" />
   <?php else: ?>
-    <img class="not-found" src="<?php echo get_template_directory_uri() ?>/images/404.png" alt="404 Not Found" loading="lazy" decoding="async" />
+    <img class="not-found" src="<?php echo get_template_directory_uri() ?>/images/404.png" alt="404 Not Found" decoding="async" />
   <?php endif ?>
 
   <?php echo wpautop(get_404_page_message()); ?>

--- a/tmp/category-content.php
+++ b/tmp/category-content.php
@@ -19,7 +19,7 @@ if ($eye_catch_url || $content): ?>
     <?php if ($eye_catch_url): ?>
       <div class="eye-catch-wrap">
         <figure class="eye-catch">
-          <img src="<?php echo esc_url($eye_catch_url); ?>" class="eye-catch-image wp-category-image" alt="<?php echo esc_attr(get_the_category_title($cat_id)); ?>" loading="lazy" decoding="async">
+          <img src="<?php echo esc_url($eye_catch_url); ?>" class="eye-catch-image wp-category-image" alt="<?php echo esc_attr(get_the_category_title($cat_id)); ?>" decoding="async">
           <?php //カテゴリラベル
           // echo get_original_image_tag($eye_catch_url, $width, $height, '"eye-catch-image wp-category-image', get_the_category_title($cat_id));
           if (apply_filters('is_eyecatch_category_label_visible', true)) {

--- a/tmp/tag-content.php
+++ b/tmp/tag-content.php
@@ -19,7 +19,7 @@ if ($eye_catch_url || $content): ?>
     <?php if ($eye_catch_url): ?>
       <div class="eye-catch-wrap">
         <figure class="eye-catch">
-          <img src="<?php echo esc_url($eye_catch_url); ?>" class="eye-catch-image wp-tag-image" alt="<?php echo esc_attr(get_the_tag_title($tag_id)); ?>" loading="lazy" decoding="async">
+          <img src="<?php echo esc_url($eye_catch_url); ?>" class="eye-catch-image wp-tag-image" alt="<?php echo esc_attr(get_the_tag_title($tag_id)); ?>" decoding="async">
         </figure>
       </div>
       <?php do_action('tag_eye_catch_after'); ?>


### PR DESCRIPTION
アイキャッチ画像にある loading="lazy" を削除する内容です。

参考：[新たに追加されたアイキャッチ画像の loading="lazy" について](https://wp-cocoon.com/community/demands/%e6%96%b0%e3%81%9f%e3%81%ab%e8%bf%bd%e5%8a%a0%e3%81%95%e3%82%8c%e3%81%9f%e3%82%a2%e3%82%a4%e3%82%ad%e3%83%a3%e3%83%83%e3%83%81%e7%94%bb%e5%83%8f%e3%81%ae-loadinglazy-%e3%81%ab%e3%81%a4%e3%81%84/)