### PR TITLE
Update Ranking block

### DIFF
--- a/blocks/src/block/ranking/edit.js
+++ b/blocks/src/block/ranking/edit.js
@@ -15,7 +15,10 @@ export default function edit(props) {
     if (typeof gbItemRankings !== 'undefined') {
       gbItemRankings.forEach((rank) => {
         if (rank.visible == '1') {
-          options.push({ value: rank.id, label: rank.title });
+          options.push({ value: rank.id, label: rank.title, disabled: false });
+        }
+        else {
+          options.push({ value: rank.id, label: rank.title, disabled: true });
         }
       });
     }

--- a/blocks/src/block/ranking/index.php
+++ b/blocks/src/block/ranking/index.php
@@ -2,6 +2,10 @@
 
 function render_ranking_list($attributes, $content) {
   $id = $attributes['id'];
+  $record = get_item_ranking($id);
+  if ($record->visible == false) {
+    return;
+  }
   //返り値がないechoとかのHTML出力結果を取得する
   ob_start();
   generate_item_ranking_tag($id);

--- a/lib/page-item-ranking/item-ranking-func.php
+++ b/lib/page-item-ranking/item-ranking-func.php
@@ -266,6 +266,9 @@ endif;
 if ( !function_exists( 'generate_item_ranking_tag' ) ):
 function generate_item_ranking_tag($id, $is_first_only = false){
   $record = get_item_ranking($id);
+  if ($record->visible == false) {
+    return;
+  }
   $items = isset($record->item_ranking) ? $record->item_ranking : array();
   $count = isset($record->count) ? intval($record->count) : 1;
   //$demo_class = $is_first_only ? ' demo' : '';

--- a/lib/page-item-ranking/item-ranking-func.php
+++ b/lib/page-item-ranking/item-ranking-func.php
@@ -266,9 +266,6 @@ endif;
 if ( !function_exists( 'generate_item_ranking_tag' ) ):
 function generate_item_ranking_tag($id, $is_first_only = false){
   $record = get_item_ranking($id);
-  if ($record->visible == false) {
-    return;
-  }
   $items = isset($record->item_ranking) ? $record->item_ranking : array();
   $count = isset($record->count) ? intval($record->count) : 1;
   //$demo_class = $is_first_only ? ' demo' : '';


### PR DESCRIPTION
- visible != '1'の場合にoptionにdisabled属性を追加
- visible != '1'の場合generate_item_ranking_tagでhtmlの生成を行わないように変更

これで[#76](https://github.com/xserver-inc/cocoon/pull/76#issuecomment-1308700328)の懸念点は解消できないでしょうか。
ご確認よろしくお願いいたします。