### PR TITLE
metadataのBlock Stylesを適用

### DIFF
--- a/blocks/src/block/icon-box/block.json
+++ b/blocks/src/block/icon-box/block.json
@@ -5,10 +5,6 @@
   "keywords": [ "icon", "box" ],
 
   "attributes": {
-    "style": {
-      "type": "string",
-      "default": "information-box"
-    }
   },
   "example": {
     "innerBlocks": [
@@ -22,5 +18,7 @@
   },
   "supports": {
     "anchor": true
-  }
+  },
+  "editorStyle": "common-icon-box block-box",
+  "style": "common-icon-box block-box"
 }

--- a/blocks/src/block/icon-box/deprecated.js
+++ b/blocks/src/block/icon-box/deprecated.js
@@ -1,24 +1,32 @@
 /**
- * Cocoon Blocks
+ * @package Cocoon Blocks
  * @author: yhira
  * @link: https://wp-cocoon.com/
  * @license: http://www.gnu.org/licenses/gpl-2.0.html GPL v2 or later
  */
 
-import { THEME_NAME, CLICK_POINT_MSG} from '../../helpers';
+/**
+ * External dependencies
+ */
 import classnames from 'classnames';
 
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 const { createBlock } = wp.blocks;
-const { InnerBlocks, InspectorControls } = wp.editor;
-const { PanelBody, SelectControl } = wp.components;
+const { InnerBlocks } = wp.editor;
 import { Fragment } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import { CLICK_POINT_MSG} from '../../helpers';
+
 //classの取得
-function getClasses(style) {
+function getClasses() {
   const classes = classnames(
     {
-      [ style ]: !! style,
       'common-icon-box': true,
       [ 'block-box' ]: true,
     }
@@ -31,10 +39,6 @@ export default [{
     content: {
       type: 'string',
       default: CLICK_POINT_MSG,
-    },
-    style: {
-      type: 'string',
-      default: 'information-box'
     },
   },
   transforms: {
@@ -71,65 +75,11 @@ export default [{
   },
 
   edit( { attributes, setAttributes, className } ) {
-    const { content, style } = attributes;
+    const { content } = attributes;
 
     return (
       <Fragment>
-        <InspectorControls>
-          <PanelBody title={ __( 'スタイル設定', THEME_NAME ) }>
-
-            <SelectControl
-              label={ __( 'タイプ', THEME_NAME ) }
-              value={ style }
-              onChange={ ( value ) => setAttributes( { style: value } ) }
-              options={ [
-                {
-                  value: 'information-box',
-                  label: __( '補足情報(i)', THEME_NAME ),
-                },
-                {
-                  value: 'question-box',
-                  label: __( '補足情報(?)', THEME_NAME ),
-                },
-                {
-                  value: 'alert-box',
-                  label: __( '補足情報(!)', THEME_NAME ),
-                },
-                {
-                  value: 'memo-box',
-                  label: __( 'メモ', THEME_NAME ),
-                },
-                {
-                  value: 'comment-box',
-                  label: __( 'コメント', THEME_NAME ),
-                },
-                {
-                  value: 'ok-box',
-                  label: __( 'OK', THEME_NAME ),
-                },
-                {
-                  value: 'ng-box',
-                  label: __( 'NG', THEME_NAME ),
-                },
-                {
-                  value: 'good-box',
-                  label: __( 'GOOD', THEME_NAME ),
-                },
-                {
-                  value: 'bad-box',
-                  label: __( 'BAD', THEME_NAME ),
-                },
-                {
-                  value: 'profile-box',
-                  label: __( 'プロフィール', THEME_NAME ),
-                },
-              ] }
-            />
-
-          </PanelBody>
-        </InspectorControls>
-
-        <div className={ classnames(getClasses(style), className) }>
+        <div className={ classnames(getClasses(), className) }>
           <InnerBlocks />
         </div>
       </Fragment>
@@ -137,9 +87,9 @@ export default [{
   },
 
   save( { attributes } ) {
-    const { content, style } = attributes;
+    const { content } = attributes;
     return (
-      <div className={ getClasses(style) }>
+      <div className={ getClasses() }>
         <InnerBlocks.Content />
       </div>
     );

--- a/blocks/src/block/icon-box/edit.js
+++ b/blocks/src/block/icon-box/edit.js
@@ -1,82 +1,23 @@
-import { THEME_NAME } from '../../helpers';
+/**
+ * @package Cocoon Blocks
+ * @author: yhira
+ * @link: https://wp-cocoon.com/
+ * @license: http://www.gnu.org/licenses/gpl-2.0.html GPL v2 or later
+ */
+
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
-import { InnerBlocks, InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { PanelBody, SelectControl } from '@wordpress/components';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { Fragment } from '@wordpress/element';
-import classnames from 'classnames';
 
-
-export default function edit({ attributes, setAttributes, className }) {
-  const { style } = attributes;
-  const classes = classnames('common-icon-box', 'block-box',
-    {
-      [ style ]: !! style,
-      [ className ]: !! className,
-    }
-  );
-  const blockProps = useBlockProps({
-    className: classes,
-  });
-
-  return (
-    <Fragment>
-      <InspectorControls>
-        <PanelBody title={ __( 'スタイル設定', THEME_NAME ) }>
-
-          <SelectControl
-            label={ __( 'タイプ', THEME_NAME ) }
-            value={ style }
-            onChange={ ( value ) => setAttributes( { style: value } ) }
-            options={ [
-              {
-                value: 'information-box',
-                label: __( '補足情報(i)', THEME_NAME ),
-              },
-              {
-                value: 'question-box',
-                label: __( '補足情報(?)', THEME_NAME ),
-              },
-              {
-                value: 'alert-box',
-                label: __( '補足情報(!)', THEME_NAME ),
-              },
-              {
-                value: 'memo-box',
-                label: __( 'メモ', THEME_NAME ),
-              },
-              {
-                value: 'comment-box',
-                label: __( 'コメント', THEME_NAME ),
-              },
-              {
-                value: 'ok-box',
-                label: __( 'OK', THEME_NAME ),
-              },
-              {
-                value: 'ng-box',
-                label: __( 'NG', THEME_NAME ),
-              },
-              {
-                value: 'good-box',
-                label: __( 'GOOD', THEME_NAME ),
-              },
-              {
-                value: 'bad-box',
-                label: __( 'BAD', THEME_NAME ),
-              },
-              {
-                value: 'profile-box',
-                label: __( 'プロフィール', THEME_NAME ),
-              },
-            ] }
-          />
-
-        </PanelBody>
-      </InspectorControls>
-
-      <div { ...blockProps }>
-        <InnerBlocks />
-      </div>
-    </Fragment>
-  );
+export default function edit() {
+	return (
+		<Fragment>
+			<div { ...useBlockProps() }>
+				<InnerBlocks />
+			</div>
+		</Fragment>
+	);
 }

--- a/blocks/src/block/icon-box/index.js
+++ b/blocks/src/block/icon-box/index.js
@@ -1,30 +1,82 @@
 /**
- * Cocoon Blocks
+ * @package Cocoon Blocks
  * @author: yhira
  * @link: https://wp-cocoon.com/
  * @license: http://www.gnu.org/licenses/gpl-2.0.html GPL v2 or later
  */
 
-import { THEME_NAME } from '../../helpers';
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { Icon, warning } from '@wordpress/icons';
 
-import edit from './edit';
-import save from './save';
+/**
+ * Internal dependencies
+ */
 import deprecated from './deprecated';
-import transforms from './transforms';
+import edit from './edit';
 import metadata from './block.json';
+import save from './save';
+import transforms from './transforms';
+import { THEME_NAME } from '../../helpers';
 
 const { name } = metadata;
+
 export { metadata, name };
 
 export const settings = {
-  title: __( 'アイコンボックス', THEME_NAME ),
-  icon: <Icon icon={warning} size={32} />,
-  description: __( 'アイコンを用いて直感的にメッセージ内容を伝えるためのボックスです。', THEME_NAME ),
-
-  edit,
-  save,
-  deprecated,
-  transforms,
+	title: __( 'アイコンボックス', THEME_NAME ),
+	icon: <Icon icon={ warning } size={ 32 } />,
+	description: __(
+		'アイコンを用いて直感的にメッセージ内容を伝えるためのボックスです。',
+		THEME_NAME
+	),
+	styles: [
+		{
+			name: 'information-box',
+			label: __( '補足情報(i)', THEME_NAME ),
+			isDefault: true,
+		},
+		{
+			name: 'question-box',
+			label: __( '補足情報(?)', THEME_NAME ),
+		},
+		{
+			name: 'alert-box',
+			label: __( '補足情報(!)', THEME_NAME ),
+		},
+		{
+			name: 'memo-box',
+			label: __( 'メモ', THEME_NAME ),
+		},
+		{
+			name: 'comment-box',
+			label: __( 'コメント', THEME_NAME ),
+		},
+		{
+			name: 'ok-box',
+			label: __( 'OK', THEME_NAME ),
+		},
+		{
+			name: 'ng-box',
+			label: __( 'NG', THEME_NAME ),
+		},
+		{
+			name: 'good-box',
+			label: __( 'GOOD', THEME_NAME ),
+		},
+		{
+			name: 'bad-box',
+			label: __( 'BAD', THEME_NAME ),
+		},
+		{
+			name: 'profile-box',
+			label: __( 'プロフィール', THEME_NAME ),
+		},
+	],
+	edit,
+	save,
+	deprecated,
+	transforms,
 };

--- a/blocks/src/block/icon-box/index.php
+++ b/blocks/src/block/icon-box/index.php
@@ -1,11 +1,32 @@
 <?php
+/**
+ * Server-side rendering of the `cocoon-blocks/icon-box` block.
+ *
+ * @package Cocoon
+ * @author yhira
+ * @link https://wp-cocoon.com/
+ * @license: http://www.gnu.org/licenses/gpl-2.0.html GPL v2 or later
+ */
 
-if( function_exists('register_block_type_from_metadata')) {
-  add_action( 'init', 'register_block_cocoon_icon_box', 99 );
-  function register_block_cocoon_icon_box() {
-    register_block_type_from_metadata(
-      __DIR__,
-      array()
-    );
-  }
+/**
+ * Renders the `cocoon-blocks/icon-box` block on the server.
+ *
+ * @param  array  $attributes The block attributes.
+ * @param  string $content    The block content.
+ * @return string Returns the block content.
+ */
+// function render_block_cocoon_block_icon_box($attributes, $content)
+// {
+// 	return;
+// }
+
+/**
+ * Registers the `cocoon-blocks/icon-box` block on server.
+ */
+function register_block_cocoon_block_icon_box()
+{
+	register_block_type(__DIR__, [
+		//'render_callback' => 'render_block_cocoon_block_icon_box',
+	]);
 }
+add_action('init', 'register_block_cocoon_block_icon_box', 99);

--- a/blocks/src/block/icon-box/save.js
+++ b/blocks/src/block/icon-box/save.js
@@ -1,19 +1,19 @@
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
-import classnames from 'classnames';
+/**
+ * @package Cocoon Blocks
+ * @author: yhira
+ * @link: https://wp-cocoon.com/
+ * @license: http://www.gnu.org/licenses/gpl-2.0.html GPL v2 or later
+ */
 
-export default function save({ attributes }) {
-  const { style } = attributes;
-  const classes = classnames('common-icon-box', 'block-box',
-    {
-      [ style ]: !! style,
-    }
-  );
-  const blockProps = useBlockProps.save({
-    className: classes,
-  });
-  return (
-    <div { ...blockProps }>
-      <InnerBlocks.Content />
-    </div>
-  );
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+export default function save() {
+	return (
+		<div { ...useBlockProps.save() }>
+			<InnerBlocks.Content />
+		</div>
+	);
 }

--- a/blocks/src/block/icon-box/transforms.js
+++ b/blocks/src/block/icon-box/transforms.js
@@ -1,3 +1,13 @@
+/**
+ * @package Cocoon Blocks
+ * @author: yhira
+ * @link: https://wp-cocoon.com/
+ * @license: http://www.gnu.org/licenses/gpl-2.0.html GPL v2 or later
+ */
+
+/**
+ * WordPress dependencies
+ */
 import { createBlock } from '@wordpress/blocks';
 
 export default {


### PR DESCRIPTION
試験的にGutenberg標準のstylesを適用してみました。

https://ja.wordpress.org/team/handbook/block-editor/reference-guides/block-api/block-metadata/#block-styles