### PR TITLE
type被りによると思われるエラーの修正

### DIFF
--- a/blocks/src/block/new-list/block.json
+++ b/blocks/src/block/new-list/block.json
@@ -13,7 +13,7 @@
       "type": "integer",
       "default": 5
     },
-    "type": {
+    "displayType": {
       "enum": [ "default", "border_partition", "border_square", "large_thumb", "large_thumb_on"],
       "default": "default"
     },

--- a/blocks/src/block/new-list/edit.js
+++ b/blocks/src/block/new-list/edit.js
@@ -36,7 +36,7 @@ export default function edit( props ) {
 	const { attributes, setAttributes, className } = props;
 	const {
 		count,
-		type,
+		displayType,
 		bold,
 		arrow,
 		showAllCats,
@@ -108,9 +108,9 @@ export default function edit( props ) {
 					/>
 					<SelectControl
 						label={ __( '表示タイプ', THEME_NAME ) }
-						value={ type }
+						value={ displayType }
 						onChange={ ( newType ) =>
-							setAttributes( { type: newType } )
+							setAttributes( { displayType: newType } )
 						}
 						options={ [
 							{

--- a/blocks/src/block/new-list/index.php
+++ b/blocks/src/block/new-list/index.php
@@ -22,7 +22,7 @@ function render_block_cocoon_block_new_list($attributes, $content)
 		'count' => $attributes['count'],
 		'cats' => $attributes['showAllCats'] ? 'all' : $attributes['cats'],
 		'tags' => $attributes['showAllTags'] ? 'all' : $attributes['tags'],
-		'type' => $attributes['type'],
+		'type' => $attributes['displayType'],
 		'children' => $attributes['children'] ? 1 : 0,
 		'post_type' => $attributes['post_type'],
 		'taxonomy' => $attributes['taxonomy'],

--- a/blocks/src/block/popular-list/block.json
+++ b/blocks/src/block/popular-list/block.json
@@ -33,7 +33,7 @@
       "type": "integer",
       "default": 5
     },
-    "type": {
+    "displayType": {
       "enum": [ "default", "border_partition", "border_square", "large_thumb", "large_thumb_on"],
       "default": "default"
     },

--- a/blocks/src/block/popular-list/edit.js
+++ b/blocks/src/block/popular-list/edit.js
@@ -41,7 +41,7 @@ export default function edit( props ) {
 		pv,
 		post_type,
 		count,
-		type,
+		displayType,
 		bold,
 		arrow,
 		showAllCats,
@@ -113,9 +113,9 @@ export default function edit( props ) {
 					{ daysNumberControl }
 					<SelectControl
 						label={ __( '表示タイプ', THEME_NAME ) }
-						value={ type }
+						value={ displayType }
 						onChange={ ( newType ) =>
-							setAttributes( { type: newType } )
+							setAttributes( { displayType: newType } )
 						}
 						options={ [
 							{

--- a/blocks/src/block/popular-list/index.php
+++ b/blocks/src/block/popular-list/index.php
@@ -21,7 +21,7 @@ function render_block_cocoon_block_popular_list($attributes, $content)
 	$atts = [
 		'days' => $attributes['showAllDays'] ? 'all' : $attributes['days'],
 		'count' => $attributes['count'],
-		'type' => $attributes['type'],
+		'type' => $attributes['displayType'],
 		'rank' => $attributes['rank'] ? 1 : 0,
 		'pv' => $attributes['pv'] ? 1 : 0,
 		'cats' => $attributes['showAllCats'] ? 'all' : $attributes['cats'],


### PR DESCRIPTION
popular-listブランチですが、new-listも修正しています。

エディタ画面で「カードの上下に区切り線を入れる」と「カードに枠線を表示する」が反映されないのですが、そちらの環境では如何でしょうか。プレビュー画面では正しくスタイルが適用されています。

ご確認よろしくお願いします。