### PR TITLE
セーブ時にprettierを実行する対象をjavascriptに限定

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,9 @@
 {
   //"codic.case": "PascalCase",
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
+  "[javascript]": {
+    "editor.formatOnSave": true
+  },
   "extensions.ignoreRecommendations": false,
   "terminal.integrated.profiles.osx": {
     "zsh": {


### PR DESCRIPTION
javascriptはセーブ実行時に、それ以外のファイルはコマンドから手動で実行すればフォーマットされます。