### PR TITLE
マイクロテキストブロック カスタム色を選択した場合のみstyleを設定するように変更

### DIFF
--- a/blocks/src/micro/micro-text/edit.js
+++ b/blocks/src/micro/micro-text/edit.js
@@ -25,7 +25,7 @@ export function MicroTextEdit( props ) {
   const { attributes, setAttributes, className, textColor, setTextColor } =
     props;
 
-  const { content, type, icon } = attributes;
+  const { content, type, icon, customTextColor } = attributes;
 
   const classes = classnames( className, {
     // [ 'wp-block' ]: true,
@@ -37,7 +37,7 @@ export function MicroTextEdit( props ) {
   } );
 
   const styles = {
-    '--cocoon-custom-text-color': textColor.color || undefined,
+    '--cocoon-custom-text-color': customTextColor || undefined,
   };
 
   const blockProps = useBlockProps( {

--- a/blocks/src/micro/micro-text/save.js
+++ b/blocks/src/micro/micro-text/save.js
@@ -21,7 +21,7 @@ export default function save( { attributes } ) {
   } );
 
   const styles = {
-    '--cocoon-custom-text-color': textColor || customTextColor || undefined,
+    '--cocoon-custom-text-color': customTextColor || undefined,
   };
 
   const blockProps = useBlockProps.save( {


### PR DESCRIPTION
表題の通り、カスタム色を選択した場合のみstyleを適用する変更です。
マイクロテキストブロックを選んだのは指定する色が一つだけのため、確認が簡単というだけの理由です。

## エディタ画面

### 定義色
<img width="326" alt="editor-defined-color" src="https://user-images.githubusercontent.com/12522500/229299298-5e63d5ae-9345-45c7-89db-ff16fcf3de89.PNG">

#### カスタム色
<img width="317" alt="editor-custom-color" src="https://user-images.githubusercontent.com/12522500/229299303-f7633097-df41-40dd-a938-1b6a881e4a2b.PNG">

## プレビュー画面

### 定義色
<img width="281" alt="preview-defined-color" src="https://user-images.githubusercontent.com/12522500/229299308-72c0e2e0-3e70-4ba2-98be-cbddd9aabc48.PNG">

#### カスタム色
<img width="273" alt="preview-custom-color" src="https://user-images.githubusercontent.com/12522500/229299315-40d882f9-e4b9-462c-af64-fb3c8cd40714.PNG">

問題なければ他のブロックにも展開します。
