### PR TITLE
タブボックスブロック カスタム色を選択した場合のみstyleを設定するように変更

### DIFF
--- a/blocks/src/block/tab-box/edit.js
+++ b/blocks/src/block/tab-box/edit.js
@@ -29,7 +29,8 @@ export function TabBoxEdit( props ) {
     fontSize,
   } = props;
 
-  const { label } = attributes;
+  const { label, customBackgroundColor, customTextColor, customBorderColor } =
+    attributes;
 
   const classes = classnames( className, {
     'blank-box': true,
@@ -46,9 +47,9 @@ export function TabBoxEdit( props ) {
   } );
 
   const styles = {
-    '--cocoon-custom-border-color': borderColor.color || undefined,
-    '--cocoon-custom-background-color': backgroundColor.color || undefined,
-    '--cocoon-custom-text-color': textColor.color || undefined,
+    '--cocoon-custom-border-color': customBorderColor || undefined,
+    '--cocoon-custom-background-color': customBackgroundColor || undefined,
+    '--cocoon-custom-text-color': customTextColor || undefined,
   };
 
   const blockProps = useBlockProps( {

--- a/blocks/src/block/tab-box/save.js
+++ b/blocks/src/block/tab-box/save.js
@@ -41,11 +41,9 @@ export default function save( props ) {
   } );
 
   const styles = {
-    '--cocoon-custom-background-color':
-      backgroundColor || customBackgroundColor || undefined,
-    '--cocoon-custom-text-color': textColor || customTextColor || undefined,
-    '--cocoon-custom-border-color':
-      borderColor || customBorderColor || undefined,
+    '--cocoon-custom-background-color': customBackgroundColor || undefined,
+    '--cocoon-custom-text-color': customTextColor || undefined,
+    '--cocoon-custom-border-color': customBorderColor || undefined,
   };
 
   const blockProps = useBlockProps.save( {


### PR DESCRIPTION
## エディタ画面

### 定義色
<img width="618" alt="tabbox-editor-defined-color" src="https://user-images.githubusercontent.com/12522500/229354012-53016403-8c6a-4bcd-b032-f3bf7492097e.PNG">

### カスタム色
<img width="614" alt="tabbox-editor-custom-color" src="https://user-images.githubusercontent.com/12522500/229354010-c9d3fc0e-a1d5-4fe8-83e2-6db3d04ce803.PNG">

## プレビュー画面

### 定義色
<img width="703" alt="tabbox-preview-defined-color" src="https://user-images.githubusercontent.com/12522500/229354021-17763988-dee4-4151-b9f1-d207414de95b.PNG">

### カスタム色
<img width="705" alt="tabbox-preview-custom-color" src="https://user-images.githubusercontent.com/12522500/229354018-5dd48fb5-3fad-4d5b-9385-c95139a26b75.PNG">

