### PR TITLE
Modify vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,11 @@
   "prettier.configPath": ".prettierrc.js",
   "prettier.ignorePath": ".prettierignore",
   "prettier.prettierPath": "node_modules/prettier",
-  "editor.tabSize": 2
+  "editor.tabSize": 2,
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true,
+    "**/node_modules/*/**": true,
+    "**/.hg/store/**": true
+  }
 }


### PR DESCRIPTION
npm startで監視対象が多すぎるエラーが発生する場合があるので設定を追加。