### PR TITLE
core/listに拡張スタイル適用

### DIFF
--- a/blocks/src/block-extension/style-extension/border01.js
+++ b/blocks/src/block-extension/style-extension/border01.js
@@ -1,0 +1,267 @@
+import { addFilter } from '@wordpress/hooks';
+import { useDebounce, createHigherOrderComponent } from '@wordpress/compose';
+import { Fragment, useState } from '@wordpress/element';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import classnames from 'classnames';
+import { THEME_NAME } from '../../helpers';
+
+// 拡張対象ブロック
+const allowedBlocks = [ 'core/paragraph' ];
+
+// custom attributesの追加
+function addCustomAttributes( settings ) {
+  if ( allowedBlocks.includes( settings.name ) ) {
+    settings.attributes = Object.assign( settings.attributes, {
+      extraBorder: {
+        type: 'string',
+        default: '',
+      },
+    } );
+  }
+  return settings;
+}
+addFilter(
+  'blocks.registerBlockType',
+  'cocoon-blocks/style-custom-attributes',
+  addCustomAttributes
+);
+
+// Edit拡張
+const addCustomEdit = createHigherOrderComponent( ( BlockEdit ) => {
+  return ( props ) => {
+    if ( allowedBlocks.includes( props.name ) && props.isSelected ) {
+      const { setAttributes, isSelected, attributes } = props;
+      const { className, extraBorder } = attributes;
+
+      const extraBorders = [
+        {
+          style: '',
+          buttonText: __( 'デフォルト', THEME_NAME ),
+        },
+        {
+          style: 'border-solid',
+          buttonText: __( '実線', THEME_NAME ),
+        },
+        {
+          style: 'border-double',
+          buttonText: __( '二重線', THEME_NAME ),
+        },
+        {
+          style: 'border-dashed',
+          buttonText: __( '破線', THEME_NAME ),
+        },
+        {
+          style: 'border-dotted',
+          buttonText: __( '点線', THEME_NAME ),
+        },
+        {
+          style: 'border-thin-and-thick',
+          buttonText: __( '薄太', THEME_NAME ),
+        },
+        {
+          style: 'border-convex',
+          buttonText: __( '微凸', THEME_NAME ),
+        },
+        {
+          style: 'border-radius-s-solid',
+          buttonText: __( '実線(角丸小)', THEME_NAME ),
+        },
+        {
+          style: 'border-radius-s-double',
+          buttonText: __( '二重線(角丸小)', THEME_NAME ),
+        },
+        {
+          style: 'border-radius-s-dashed',
+          buttonText: __( '破線(角丸小)', THEME_NAME ),
+        },
+        {
+          style: 'border-radius-s-dotted',
+          buttonText: __( '点線(角丸小)', THEME_NAME ),
+        },
+        {
+          style: 'border-radius-s-thin-and-thick',
+          buttonText: __( '薄太(角丸小)', THEME_NAME ),
+        },
+        {
+          style: 'border-radius-s-convex',
+          buttonText: __( '微凸(角丸小)', THEME_NAME ),
+        },
+        {
+          style: 'border-radius-l-solid',
+          buttonText: __( '実線(角丸大)', THEME_NAME ),
+        },
+        {
+          style: 'border-radius-l-double',
+          buttonText: __( '二重線(角丸大)', THEME_NAME ),
+        },
+        {
+          style: 'border-radius-l-dashed',
+          buttonText: __( '破線(角丸大)', THEME_NAME ),
+        },
+        {
+          style: 'border-radius-l-dotted',
+          buttonText: __( '点線(角丸大)', THEME_NAME ),
+        },
+        {
+          style: 'border-radius-l-thin-and-thick',
+          buttonText: __( '薄太(角丸大)', THEME_NAME ),
+        },
+        {
+          style: 'border-radius-l-convex',
+          buttonText: __( '微凸(角丸大)', THEME_NAME ),
+        },
+      ];
+
+      return (
+        <Fragment>
+          <BlockEdit { ...props } />
+
+          { isSelected && (
+            <InspectorControls>
+              <PanelBody
+                title={ __( '[C] ボーダー設定', THEME_NAME ) }
+                initialOpen={ false }
+              >
+                <div class="__clearBtn">
+                  <button
+                    type="button"
+                    class="components-button is-small"
+                    onClick={ () => setAttributes( { extraBorder: '' } ) }
+                  >
+                    <span class="dashicons dashicons-editor-removeformatting"></span>
+                    { __( 'ボーダーをクリア', THEME_NAME ) }
+                  </button>
+                </div>
+                <div className="block-editor-block-styles">
+                  <div className="block-editor-block-styles__variants style-buttons">
+                    { extraBorders.map( ( border, index ) => {
+                      return (
+                        <div
+                          className={ classnames( '__btnBox', {
+                            [ '__btnBoxDefault display-none' ]: ! border.style,
+                          } ) }
+                        >
+                          <Button
+                            id={ 'cocoon-dorder-border01-button-' + index }
+                            className={ classnames(
+                              'display-none',
+                              'block-editor-block-styles__item',
+                              {
+                                'is-active': border.style === extraBorder,
+                              }
+                            ) }
+                            variant="secondary"
+                            label={ border.buttonText }
+                            onClick={ () => {
+                              if ( border.style === extraBorder ) {
+                                setAttributes( { extraBorder: '' } );
+                              } else {
+                                setAttributes( { extraBorder: border.style } );
+                              }
+                            } }
+                          ></Button>
+                          <label
+                            for={ 'cocoon-dorder-border01-button-' + index }
+                            class="__labelBtn"
+                            data-selected={
+                              border.style === extraBorder ? true : false
+                            }
+                          >
+                            <span class="__prevWrap editor-styles-wrapper">
+                              <span
+                                className={ classnames( '__prev', {
+                                  [ 'is-style-' + border.style ]:
+                                    !! border.style,
+                                  [ 'has-border' ]: border.style,
+                                } ) }
+                              ></span>
+                            </span>
+                            <span class="__prevTitle">
+                              { border.buttonText }
+                            </span>
+                          </label>
+                        </div>
+                      );
+                    } ) }
+                  </div>
+                </div>
+                <div class="__clearBtn">
+                  <button
+                    type="button"
+                    class="components-button is-small"
+                    onClick={ () => setAttributes( { extraBorder: '' } ) }
+                  >
+                    <span class="dashicons dashicons-editor-removeformatting"></span>
+                    { __( 'ボーダーをクリア', THEME_NAME ) }
+                  </button>
+                </div>
+              </PanelBody>
+            </InspectorControls>
+          ) }
+        </Fragment>
+      );
+    }
+
+    return <BlockEdit { ...props } />;
+  };
+}, 'addCustomEdit' );
+addFilter(
+  'editor.BlockEdit',
+  'cocoon-blocks/style-custom-edit',
+  addCustomEdit
+);
+
+// 親ブロックへのクラス適用
+const applyAttributesToBlock = createHigherOrderComponent(
+  ( BlockListBlock ) => {
+    return ( props ) => {
+      const { attributes, className, name, isValid } = props;
+
+      if ( isValid && allowedBlocks.includes( name ) ) {
+        const { extraBorder } = attributes;
+
+        return (
+          <BlockListBlock
+            { ...props }
+            className={ classnames( className, {
+              [ 'is-style-' + extraBorder ]: !! extraBorder,
+              [ 'has-border' ]: extraBorder,
+            } ) }
+          />
+        );
+      }
+
+      return <BlockListBlock { ...props } />;
+    };
+  },
+  'applyAttributesToBlock'
+);
+addFilter(
+  'editor.BlockListBlock',
+  'cocoon-blocks/style-apply-attributes',
+  applyAttributesToBlock
+);
+
+// Save拡張
+const addCustomSave = ( props, blockType, attributes ) => {
+  if ( allowedBlocks.includes( blockType.name ) ) {
+    const { className } = props;
+    const { extraBorder } = attributes;
+
+    props.className = classnames( className, {
+      [ 'is-style-' + extraBorder ]: !! extraBorder,
+      [ 'has-border' ]: extraBorder,
+    } );
+
+    return Object.assign( props );
+  }
+  return props;
+};
+addFilter(
+  'blocks.getSaveContent.extraProps',
+  'cocoon-blocks/style-custom-save',
+  addCustomSave
+);

--- a/blocks/src/block-extension/style-extension/border01.js
+++ b/blocks/src/block-extension/style-extension/border01.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { THEME_NAME } from '../../helpers';
 
 // 拡張対象ブロック
-const allowedBlocks = [ 'core/paragraph' ];
+const allowedBlocks = [ 'core/paragraph', 'core/list' ];
 
 // custom attributesの追加
 function addCustomAttributes( settings ) {

--- a/blocks/src/block-extension/style-extension/style01.js
+++ b/blocks/src/block-extension/style-extension/style01.js
@@ -19,10 +19,6 @@ function addCustomAttributes( settings ) {
         type: 'string',
         default: '',
       },
-      extraBorder: {
-        type: 'string',
-        default: '',
-      },
     } );
   }
   return settings;
@@ -38,7 +34,7 @@ const addCustomEdit = createHigherOrderComponent( ( BlockEdit ) => {
   return ( props ) => {
     if ( allowedBlocks.includes( props.name ) && props.isSelected ) {
       const { setAttributes, isSelected, attributes } = props;
-      const { className, extraStyle, extraBorder } = attributes;
+      const { className, extraStyle } = attributes;
 
       const extraStyles = [
         {
@@ -171,177 +167,12 @@ const addCustomEdit = createHigherOrderComponent( ( BlockEdit ) => {
         },
       ];
 
-      const extraBorders = [
-        {
-          style: '',
-          buttonText: __( 'デフォルト', THEME_NAME ),
-        },
-        {
-          style: 'border-solid',
-          buttonText: __( '実線', THEME_NAME ),
-        },
-        {
-          style: 'border-double',
-          buttonText: __( '二重線', THEME_NAME ),
-        },
-        {
-          style: 'border-dashed',
-          buttonText: __( '破線', THEME_NAME ),
-        },
-        {
-          style: 'border-dotted',
-          buttonText: __( '点線', THEME_NAME ),
-        },
-        {
-          style: 'border-thin-and-thick',
-          buttonText: __( '薄太', THEME_NAME ),
-        },
-        {
-          style: 'border-convex',
-          buttonText: __( '微凸', THEME_NAME ),
-        },
-        {
-          style: 'border-radius-s-solid',
-          buttonText: __( '実線(角丸小)', THEME_NAME ),
-        },
-        {
-          style: 'border-radius-s-double',
-          buttonText: __( '二重線(角丸小)', THEME_NAME ),
-        },
-        {
-          style: 'border-radius-s-dashed',
-          buttonText: __( '破線(角丸小)', THEME_NAME ),
-        },
-        {
-          style: 'border-radius-s-dotted',
-          buttonText: __( '点線(角丸小)', THEME_NAME ),
-        },
-        {
-          style: 'border-radius-s-thin-and-thick',
-          buttonText: __( '薄太(角丸小)', THEME_NAME ),
-        },
-        {
-          style: 'border-radius-s-convex',
-          buttonText: __( '微凸(角丸小)', THEME_NAME ),
-        },
-        {
-          style: 'border-radius-l-solid',
-          buttonText: __( '実線(角丸大)', THEME_NAME ),
-        },
-        {
-          style: 'border-radius-l-double',
-          buttonText: __( '二重線(角丸大)', THEME_NAME ),
-        },
-        {
-          style: 'border-radius-l-dashed',
-          buttonText: __( '破線(角丸大)', THEME_NAME ),
-        },
-        {
-          style: 'border-radius-l-dotted',
-          buttonText: __( '点線(角丸大)', THEME_NAME ),
-        },
-        {
-          style: 'border-radius-l-thin-and-thick',
-          buttonText: __( '薄太(角丸大)', THEME_NAME ),
-        },
-        {
-          style: 'border-radius-l-convex',
-          buttonText: __( '微凸(角丸大)', THEME_NAME ),
-        },
-      ];
-
-      var index = 0;
       return (
         <Fragment>
           <BlockEdit { ...props } />
 
           { isSelected && (
             <InspectorControls>
-              <PanelBody
-                title={ __( '[C] ボーダー設定', THEME_NAME ) }
-                initialOpen={ false }
-              >
-                <div class="__clearBtn">
-                  <button
-                    type="button"
-                    class="components-button is-small"
-                    onClick={ () =>
-                      setAttributes( { extraBorder: '' } )
-                    }
-                  >
-                    <span class="dashicons dashicons-editor-removeformatting"></span>
-                    {__( 'ボーダーをクリア', THEME_NAME ) }
-                  </button>
-                </div>
-                <div className="block-editor-block-styles">
-                  <div className="block-editor-block-styles__variants style-buttons">
-                    {extraBorders.map((border) => {
-                      index++;
-                      return (
-                        <div
-                          className={classnames('__btnBox',
-                            {[ '__btnBoxDefault display-none' ]: ! border.style}
-                          )}
-                        >
-                          <Button
-                            id={ 'cocoon-dorder-button-' + index }
-                            className={ classnames(
-                              'display-none',
-                              'block-editor-block-styles__item',
-                              {
-                                'is-active': border.style === extraBorder,
-                              }
-                            ) }
-                            variant="secondary"
-                            label={ border.buttonText }
-                            onClick={ () =>
-                              {
-                                if (border.style === extraBorder) {
-                                  setAttributes( { extraBorder: '' } )
-                                } else {
-                                  setAttributes( { extraBorder: border.style } )
-                                }
-                              }
-                            }
-                          ></Button>
-                          <label
-                            for={ 'cocoon-dorder-button-' + index }
-                            class="__labelBtn"
-                            data-selected={
-                              border.style === extraBorder ? true : false
-                            }
-                          >
-                            <span class="__prevWrap editor-styles-wrapper">
-                              <span
-                                className={ classnames( '__prev', {
-                                  [ 'is-style-' + border.style ]:
-                                    !! border.style,
-                                  [ 'has-border' ]: border.style,
-                                } ) }
-                              ></span>
-                            </span>
-                            <span class="__prevTitle">
-                              { border.buttonText }
-                            </span>
-                          </label>
-                        </div>
-                      );
-                    } ) }
-                  </div>
-                </div>
-                <div class="__clearBtn">
-                  <button
-                    type="button"
-                    class="components-button is-small"
-                    onClick={ () =>
-                      setAttributes( { extraBorder: '' } )
-                    }
-                  >
-                    <span class="dashicons dashicons-editor-removeformatting"></span>
-                    {__( 'ボーダーをクリア', THEME_NAME ) }
-                  </button>
-                </div>
-              </PanelBody>
               <PanelBody
                 title={ __( '[C] スタイル', THEME_NAME ) }
                 initialOpen={ false }
@@ -350,26 +181,23 @@ const addCustomEdit = createHigherOrderComponent( ( BlockEdit ) => {
                   <button
                     type="button"
                     class="components-button is-small"
-                    onClick={ () =>
-                      setAttributes( { extraStyle: '' } )
-                    }
+                    onClick={ () => setAttributes( { extraStyle: '' } ) }
                   >
                     <span class="dashicons dashicons-editor-removeformatting"></span>
-                    {__( 'スタイルをクリア', THEME_NAME ) }
+                    { __( 'スタイルをクリア', THEME_NAME ) }
                   </button>
                 </div>
                 <div className="block-editor-block-styles">
                   <div className="block-editor-block-styles__variants style-buttons">
-                    {extraStyles.map((style) => {
-                      index++
+                    { extraStyles.map( ( style, index ) => {
                       return (
                         <div
-                          className={classnames('__btnBox',
-                            {[ '__btnBoxDefault display-none' ]: ! style.style}
-                          )}
+                          className={ classnames( '__btnBox', {
+                            [ '__btnBoxDefault display-none' ]: ! style.style,
+                          } ) }
                         >
                           <Button
-                            id={ 'cocoon-dorder-button-' + index }
+                            id={ 'cocoon-dorder-style01-button-' + index }
                             className={ classnames(
                               'display-none',
                               'block-editor-block-styles__item',
@@ -379,18 +207,16 @@ const addCustomEdit = createHigherOrderComponent( ( BlockEdit ) => {
                             ) }
                             variant="secondary"
                             label={ style.buttonText }
-                            onClick={ () =>
-                              {
-                                if (style.style === extraStyle) {
-                                  setAttributes( { extraStyle: '' } )
-                                } else {
-                                  setAttributes( { extraStyle: style.style } )
-                                }
+                            onClick={ () => {
+                              if ( style.style === extraStyle ) {
+                                setAttributes( { extraStyle: '' } );
+                              } else {
+                                setAttributes( { extraStyle: style.style } );
                               }
-                            }
+                            } }
                           ></Button>
                           <label
-                            for={ 'cocoon-dorder-button-' + index }
+                            for={ 'cocoon-dorder-style01-button-' + index }
                             class="__labelBtn"
                             data-selected={
                               style.style === extraStyle ? true : false
@@ -417,12 +243,10 @@ const addCustomEdit = createHigherOrderComponent( ( BlockEdit ) => {
                   <button
                     type="button"
                     class="components-button is-small"
-                    onClick={ () =>
-                      setAttributes( { extraStyle: '' } )
-                    }
+                    onClick={ () => setAttributes( { extraStyle: '' } ) }
                   >
                     <span class="dashicons dashicons-editor-removeformatting"></span>
-                    {__( 'スタイルをクリア', THEME_NAME ) }
+                    { __( 'スタイルをクリア', THEME_NAME ) }
                   </button>
                 </div>
               </PanelBody>
@@ -448,15 +272,13 @@ const applyAttributesToBlock = createHigherOrderComponent(
       const { attributes, className, name, isValid } = props;
 
       if ( isValid && allowedBlocks.includes( name ) ) {
-        const { extraStyle, extraBorder } = attributes;
+        const { extraStyle } = attributes;
 
         return (
           <BlockListBlock
             { ...props }
             className={ classnames( className, {
               [ 'is-style-' + extraStyle ]: !! extraStyle,
-              [ 'is-style-' + extraBorder ]: !! extraBorder,
-              [ 'has-border' ]: extraBorder,
               [ 'has-box-style' ]: extraStyle,
             } ) }
           />
@@ -478,12 +300,10 @@ addFilter(
 const addCustomSave = ( props, blockType, attributes ) => {
   if ( allowedBlocks.includes( blockType.name ) ) {
     const { className } = props;
-    const { extraStyle, extraBorder } = attributes;
+    const { extraStyle } = attributes;
 
     props.className = classnames( className, {
       [ 'is-style-' + extraStyle ]: !! extraStyle,
-      [ 'is-style-' + extraBorder ]: !! extraBorder,
-      [ 'has-border' ]: extraBorder,
       [ 'has-box-style' ]: extraStyle,
     } );
 

--- a/blocks/src/block-extension/style-extension/style02.js
+++ b/blocks/src/block-extension/style-extension/style02.js
@@ -1,0 +1,222 @@
+import { addFilter } from '@wordpress/hooks';
+import { useDebounce, createHigherOrderComponent } from '@wordpress/compose';
+import { Fragment, useState } from '@wordpress/element';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import classnames from 'classnames';
+import { THEME_NAME } from '../../helpers';
+
+// 拡張対象ブロック
+const allowedBlocks = [ 'core/list' ];
+
+// custom attributesの追加
+function addCustomAttributes( settings ) {
+  if ( allowedBlocks.includes( settings.name ) ) {
+    settings.attributes = Object.assign( settings.attributes, {
+      extraStyle: {
+        type: 'string',
+        default: '',
+      },
+    } );
+  }
+  return settings;
+}
+addFilter(
+  'blocks.registerBlockType',
+  'cocoon-blocks/style-custom-attributes',
+  addCustomAttributes
+);
+
+// Edit拡張
+const addCustomEdit = createHigherOrderComponent( ( BlockEdit ) => {
+  return ( props ) => {
+    if ( allowedBlocks.includes( props.name ) && props.isSelected ) {
+      const { setAttributes, isSelected, attributes } = props;
+      const { className, extraStyle } = attributes;
+
+      const extraStyles = [
+        {
+          style: '',
+          buttonText: __( 'デフォルト', THEME_NAME ),
+        },
+        {
+          style: 'table-of-contents-list',
+          buttonText: __( '目次風', THEME_NAME ),
+        },
+        {
+          style: 'check-list',
+          buttonText: __( 'チェック', THEME_NAME ),
+        },
+        {
+          style: 'circle-list',
+          buttonText: __( 'マル', THEME_NAME ),
+        },
+        {
+          style: 'triangle-list',
+          buttonText: __( '三角', THEME_NAME ),
+        },
+        {
+          style: 'cross-list',
+          buttonText: __( 'バツ', THEME_NAME ),
+        },
+        {
+          style: 'enclosed-numeric-list',
+          buttonText: __( '丸数字', THEME_NAME ),
+        },
+        {
+          style: 'annotation-list',
+          buttonText: __( '注釈', THEME_NAME ),
+        },
+      ];
+
+      return (
+        <Fragment>
+          <BlockEdit { ...props } />
+
+          { isSelected && (
+            <InspectorControls>
+              <PanelBody
+                title={ __( '[C] スタイル', THEME_NAME ) }
+                initialOpen={ false }
+              >
+                <div class="__clearBtn">
+                  <button
+                    type="button"
+                    class="components-button is-small"
+                    onClick={ () => setAttributes( { extraStyle: '' } ) }
+                  >
+                    <span class="dashicons dashicons-editor-removeformatting"></span>
+                    { __( 'スタイルをクリア', THEME_NAME ) }
+                  </button>
+                </div>
+                <div className="block-editor-block-styles">
+                  <div className="block-editor-block-styles__variants style-buttons">
+                    { extraStyles.map( ( style, index ) => {
+                      return (
+                        <div
+                          className={ classnames( '__btnBox', {
+                            [ '__btnBoxDefault display-none' ]: ! style.style,
+                          } ) }
+                        >
+                          <Button
+                            id={ 'cocoon-dorder-style02-button-' + index }
+                            className={ classnames(
+                              'display-none',
+                              'block-editor-block-styles__item',
+                              {
+                                'is-active': style.style === extraStyle,
+                              }
+                            ) }
+                            variant="secondary"
+                            label={ style.buttonText }
+                            onClick={ () => {
+                              if ( style.style === extraStyle ) {
+                                setAttributes( { extraStyle: '' } );
+                              } else {
+                                setAttributes( { extraStyle: style.style } );
+                              }
+                            } }
+                          ></Button>
+                          <label
+                            for={ 'cocoon-dorder-style02-button-' + index }
+                            class="__labelBtn"
+                            data-selected={
+                              style.style === extraStyle ? true : false
+                            }
+                          >
+                            <span class="__prevWrap editor-styles-wrapper">
+                              <span
+                                className={ classnames( '__prev', {
+                                  [ 'is-style-' + style.style ]: !! style.style,
+                                  [ 'has-box-style' ]: style.style,
+                                } ) }
+                              ></span>
+                            </span>
+                            <span class="__prevTitle">
+                              { style.buttonText }
+                            </span>
+                          </label>
+                        </div>
+                      );
+                    } ) }
+                  </div>
+                </div>
+                <div class="__clearBtn">
+                  <button
+                    type="button"
+                    class="components-button is-small"
+                    onClick={ () => setAttributes( { extraStyle: '' } ) }
+                  >
+                    <span class="dashicons dashicons-editor-removeformatting"></span>
+                    { __( 'スタイルをクリア', THEME_NAME ) }
+                  </button>
+                </div>
+              </PanelBody>
+            </InspectorControls>
+          ) }
+        </Fragment>
+      );
+    }
+
+    return <BlockEdit { ...props } />;
+  };
+}, 'addCustomEdit' );
+addFilter(
+  'editor.BlockEdit',
+  'cocoon-blocks/style-custom-edit',
+  addCustomEdit
+);
+
+// 親ブロックへのクラス適用
+const applyAttributesToBlock = createHigherOrderComponent(
+  ( BlockListBlock ) => {
+    return ( props ) => {
+      const { attributes, className, name, isValid } = props;
+
+      if ( isValid && allowedBlocks.includes( name ) ) {
+        const { extraStyle } = attributes;
+
+        return (
+          <BlockListBlock
+            { ...props }
+            className={ classnames( className, {
+              [ 'is-style-' + extraStyle ]: !! extraStyle,
+              [ 'has-box-style' ]: extraStyle,
+            } ) }
+          />
+        );
+      }
+
+      return <BlockListBlock { ...props } />;
+    };
+  },
+  'applyAttributesToBlock'
+);
+addFilter(
+  'editor.BlockListBlock',
+  'cocoon-blocks/style-apply-attributes',
+  applyAttributesToBlock
+);
+
+// Save拡張
+const addCustomSave = ( props, blockType, attributes ) => {
+  if ( allowedBlocks.includes( blockType.name ) ) {
+    const { className } = props;
+    const { extraStyle } = attributes;
+
+    props.className = classnames( className, {
+      [ 'is-style-' + extraStyle ]: !! extraStyle,
+      [ 'has-box-style' ]: extraStyle,
+    } );
+
+    return Object.assign( props );
+  }
+  return props;
+};
+addFilter(
+  'blocks.getSaveContent.extraProps',
+  'cocoon-blocks/style-custom-save',
+  addCustomSave
+);

--- a/blocks/src/blocks.js
+++ b/blocks/src/blocks.js
@@ -115,7 +115,8 @@ registerCocoonBlocks();
 
 //デフォルトブロックの拡張
 import './custom/code/block.js';
-import './block-extension/style-extension/block.js';
+import './block-extension/style-extension/border01.js';
+import './block-extension/style-extension/style01.js';
 
 //レイアウト
 import './layout/column-children/block.js';

--- a/blocks/src/blocks.js
+++ b/blocks/src/blocks.js
@@ -115,8 +115,13 @@ registerCocoonBlocks();
 
 //デフォルトブロックの拡張
 import './custom/code/block.js';
+
+// ボーダー拡張
 import './block-extension/style-extension/border01.js';
+
+// スタイル拡張
 import './block-extension/style-extension/style01.js';
+import './block-extension/style-extension/style02.js';
 
 //レイアウト
 import './layout/column-children/block.js';


### PR DESCRIPTION
core/paragraphの拡張で作成したblock.jsをborder01, style01に分割、
core/listにはborder01とstyle02を適用しました。

labelとbuttonにつけるidを`cocoon-dorder-<filename>-button-<index>`に変更しました。(filenameを追加)
ご留意ください。