### PR TITLE
prop classNameの判定を追加

### DIFF
--- a/blocks/src/block-extension/style-extension/block.js
+++ b/blocks/src/block-extension/style-extension/block.js
@@ -453,7 +453,8 @@ const applyAttributesToBlock = createHigherOrderComponent(
         return (
           <BlockListBlock
             { ...props }
-            className={ classnames( className, {
+            className={ classnames( {
+              className: !! className,
               [ 'is-style-' + extraStyle ]: !! extraStyle,
               [ 'is-style-' + extraBorder ]: !! extraBorder,
               [ 'has-border' ]: extraBorder,
@@ -480,14 +481,13 @@ const addCustomSave = ( props, blockType, attributes ) => {
     const { className } = props;
     const { extraStyle, extraBorder } = attributes;
 
-    if (extraStyle || extraBorder) {
-      props.className = classnames( className, {
-        [ 'is-style-' + extraStyle ]: !! extraStyle,
-        [ 'is-style-' + extraBorder ]: !! extraBorder,
-        [ 'has-border' ]: extraBorder,
-        [ 'has-box-style' ]: extraStyle,
-      } );
-    }
+    props.className = classnames( {
+      className: !! className,
+      [ 'is-style-' + extraStyle ]: !! extraStyle,
+      [ 'is-style-' + extraBorder ]: !! extraBorder,
+      [ 'has-border' ]: extraBorder,
+      [ 'has-box-style' ]: extraStyle,
+    } );
 
     return Object.assign( props );
   }


### PR DESCRIPTION
何かしらのテーマの拡張でprops.classNameが渡ってくる可能性を考え、classNameの判定も行いclassを追加するようにしてみました。

この変更で私の環境では問題は起きていません。
ご確認よろしくお願いします。

![image](https://github.com/xserver-inc/cocoon/assets/12522500/e56e02a7-1373-4757-89c1-f5f00d7eef19)
