### PR TITLE
silkスキン https時にコードコピーを行うと複数のコードブロックの内容がコピーされる不具合修正

### DIFF
--- a/skins/silk/functions.php
+++ b/skins/silk/functions.php
@@ -1287,7 +1287,7 @@ class Skin_Silk_Functions {
               //クリック動作をキャンセル
               event.preventDefault();
 
-              navigator.clipboard.writeText($(selector).parent().text()).then(
+              navigator.clipboard.writeText($(this).parent().text()).then(
                 () => {
                   const info = $(".copy-info").text();
                   $(".copy-info").text("コードをコピーしました").fadeIn(500).delay(1000).fadeOut(500, function() {


### PR DESCRIPTION
## 再現条件

- silkスキン
- https時
- ソースコードをハイライト表示：有効

複数のコードブロックがある場合に、コードのコピーを行うと
複数のコードブロックの内容がコピーされる。

<img width="636" alt="2023-09-14_21h37_10" src="https://github.com/xserver-inc/cocoon/assets/49362513/89b71874-84fe-4ad6-a9a8-76eb15be1222">

コピーされる内容

```
AAABBB
```

## 期待動作

該当のコードブロックのみコピーされる

```
AAA
```

お手数ですが、ご確認お願い致します。

