### PR TITLE
Cocoonボタンの設定に幅を追加

### DIFF
--- a/blocks/src/block/button/block.json
+++ b/blocks/src/block/button/block.json
@@ -52,6 +52,9 @@
     },
     "fontSize": {
       "type": "string"
+    },
+    "width": {
+      "type": "string"
     }
   },
   "example": {

--- a/blocks/src/block/button/edit.js
+++ b/blocks/src/block/button/edit.js
@@ -14,6 +14,8 @@ import {
   SelectControl,
   TextControl,
   ToggleControl,
+  Button,
+  ButtonGroup,
 } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
@@ -45,6 +47,7 @@ export function ButtonEdit( props ) {
     customBackgroundColor,
     customTextColor,
     customBorderColor,
+    width,
   } = attributes;
 
   const classes = classnames( className, {
@@ -56,6 +59,35 @@ export function ButtonEdit( props ) {
     '--cocoon-custom-background-color': customBackgroundColor || undefined,
     '--cocoon-custom-text-color': customTextColor || undefined,
   };
+
+  function WidthPanel( { selectedWidth, setAttributes } ) {
+    function handleChange( newWidth ) {
+      // Check if we are toggling the width off
+      const width = selectedWidth === newWidth ? undefined : newWidth;
+
+      // Update attributes
+      setAttributes( { width } );
+    }
+
+    return (
+      <PanelBody title={ __( '幅設定', THEME_NAME ) }>
+        <ButtonGroup aria-label={ __( 'ボタン幅', THEME_NAME ) }>
+          { [ 25, 50, 75, 100 ].map( ( widthValue ) => {
+            return (
+              <Button
+                key={ widthValue }
+                isSmall
+                isPrimary={ widthValue === selectedWidth }
+                onClick={ () => handleChange( widthValue ) }
+              >
+                { widthValue }%
+              </Button>
+            );
+          } ) }
+        </ButtonGroup>
+      </PanelBody>
+    );
+  }
 
   const blockProps = useBlockProps( {
     className: classes,
@@ -121,6 +153,8 @@ export function ButtonEdit( props ) {
           />
         </PanelBody>
 
+        <WidthPanel selectedWidth={ width } setAttributes={ setAttributes } />
+
         <PanelBody
           title={ __( '文字サイズ', THEME_NAME ) }
           className="blocks-font-size"
@@ -170,6 +204,8 @@ export function ButtonEdit( props ) {
             [ textColor.class ]: textColor.class,
             [ borderColor.class ]: borderColor.class,
             [ fontSize.class ]: fontSize.class,
+            [ 'has-custom-width' ]: width,
+            [ `cocoon-block-button__width-${ width }` ]: width,
           } ) }
           href={ url }
           target={ target }

--- a/blocks/src/block/button/save.js
+++ b/blocks/src/block/button/save.js
@@ -22,6 +22,7 @@ export default function save( { attributes } ) {
     customTextColor,
     customBorderColor,
     fontSize,
+    width,
   } = attributes;
 
   const backgroundClass = getColorClassName(
@@ -64,6 +65,8 @@ export default function save( { attributes } ) {
           [ backgroundClass ]: backgroundClass,
           [ borderClass ]: borderClass,
           [ fontSizeClass ]: fontSizeClass,
+          [ 'has-custom-width' ]: width,
+          [ `cocoon-block-button__width-${ width }` ]: width,
         } ) }
         target={ target }
         rel="noopener"


### PR DESCRIPTION
下記要望に対応しました。
[Cocoonのボタンブロックに幅設定を追加希望](https://wp-cocoon.com/community/demands/cocoon%e3%81%ae%e3%83%9c%e3%82%bf%e3%83%b3%e3%83%96%e3%83%ad%e3%83%83%e3%82%af%e3%81%ab%e5%b9%85%e8%a8%ad%e5%ae%9a%e3%82%92%e8%bf%bd%e5%8a%a0%e5%b8%8c%e6%9c%9b/)

基本的にGutenbergのボタンに実装されていた内容を流用しています。
[Add a block support for dimension settings #26368](https://github.com/WordPress/gutenberg/pull/25999)

付与するクラスは`cocoon-block-button__width-xxx`(xxxに数値)としています。
ご確認よろしくお願いいたします。