### PR TITLE
囲みボタンに幅設定を追加

### DIFF
--- a/blocks/src/block/button-wrap/block.json
+++ b/blocks/src/block/button-wrap/block.json
@@ -50,6 +50,9 @@
     },
     "customFontSize": {
       "type": "string"
+    },
+    "width": {
+      "type": "string"
     }
   },
   "example": {

--- a/blocks/src/block/button-wrap/edit.js
+++ b/blocks/src/block/button-wrap/edit.js
@@ -1,4 +1,5 @@
 import { THEME_NAME, BUTTON_BLOCK } from '../../helpers';
+import { WidthPanel } from '../../components';
 import { __ } from '@wordpress/i18n';
 import {
   InspectorControls,
@@ -43,6 +44,7 @@ export function ButtonWrapEdit( props ) {
     customBackgroundColor,
     customTextColor,
     customBorderColor,
+    width,
   } = attributes;
 
   const classes = classnames( className, {
@@ -59,6 +61,8 @@ export function ButtonWrapEdit( props ) {
     [ textColor.class ]: textColor.class,
     [ borderColor.class ]: borderColor.class,
     [ fontSize.class ]: fontSize.class,
+    [ 'has-custom-width' ]: width,
+    [ `cocoon-block-button__width-${ width }` ]: width,
   } );
 
   const styles = {
@@ -115,6 +119,8 @@ export function ButtonWrapEdit( props ) {
             onChange={ ( value ) => setAttributes( { isShine: value } ) }
           />
         </PanelBody>
+
+        <WidthPanel selectedWidth={ width } setAttributes={ setAttributes } />
 
         <PanelBody
           title={ __( '文字サイズ', THEME_NAME ) }

--- a/blocks/src/block/button-wrap/save.js
+++ b/blocks/src/block/button-wrap/save.js
@@ -20,6 +20,7 @@ export default function save( { attributes } ) {
     customTextColor,
     customBorderColor,
     fontSize,
+    width,
   } = attributes;
 
   const backgroundClass = getColorClassName(
@@ -44,6 +45,8 @@ export default function save( { attributes } ) {
     [ backgroundClass ]: backgroundClass,
     [ borderClass ]: borderClass,
     [ fontSizeClass ]: fontSizeClass,
+    [ 'has-custom-width' ]: width,
+    [ `cocoon-block-button__width-${ width }` ]: width,
   } );
 
   const styles = {
@@ -59,8 +62,11 @@ export default function save( { attributes } ) {
 
   // rel属性の値をチェックして変換を行う
   let tagCode;
-  if (!tag.includes(' rel="noopener')) {
-    tagCode = tag.replace(' target="_blank"', ' target="_blank" rel="noopener"');
+  if ( ! tag.includes( ' rel="noopener' ) ) {
+    tagCode = tag.replace(
+      ' target="_blank"',
+      ' target="_blank" rel="noopener"'
+    );
   }
   return (
     <div { ...blockProps }>

--- a/blocks/src/block/button/edit.js
+++ b/blocks/src/block/button/edit.js
@@ -1,4 +1,5 @@
 import { THEME_NAME, BUTTON_BLOCK } from '../../helpers';
+import { WidthPanel } from '../../components';
 import { __ } from '@wordpress/i18n';
 import {
   InspectorControls,
@@ -14,8 +15,6 @@ import {
   SelectControl,
   TextControl,
   ToggleControl,
-  Button,
-  ButtonGroup,
 } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
@@ -59,35 +58,6 @@ export function ButtonEdit( props ) {
     '--cocoon-custom-background-color': customBackgroundColor || undefined,
     '--cocoon-custom-text-color': customTextColor || undefined,
   };
-
-  function WidthPanel( { selectedWidth, setAttributes } ) {
-    function handleChange( newWidth ) {
-      // Check if we are toggling the width off
-      const width = selectedWidth === newWidth ? undefined : newWidth;
-
-      // Update attributes
-      setAttributes( { width } );
-    }
-
-    return (
-      <PanelBody title={ __( '幅設定', THEME_NAME ) }>
-        <ButtonGroup aria-label={ __( 'ボタン幅', THEME_NAME ) }>
-          { [ '25', '50', '75', '100' ].map( ( widthValue ) => {
-            return (
-              <Button
-                key={ widthValue }
-                isSmall
-                isPrimary={ widthValue === selectedWidth }
-                onClick={ () => handleChange( widthValue ) }
-              >
-                { widthValue }%
-              </Button>
-            );
-          } ) }
-        </ButtonGroup>
-      </PanelBody>
-    );
-  }
 
   const blockProps = useBlockProps( {
     className: classes,

--- a/blocks/src/components/WidthPanel.js
+++ b/blocks/src/components/WidthPanel.js
@@ -1,0 +1,32 @@
+import { THEME_NAME } from '../helpers';
+import { PanelBody, ButtonGroup, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export default function WidthPanel( { selectedWidth, setAttributes } ) {
+  function handleChange( newWidth ) {
+    // Check if we are toggling the width off
+    const width = selectedWidth === newWidth ? undefined : newWidth;
+
+    // Update attributes
+    setAttributes( { width } );
+  }
+
+  return (
+    <PanelBody title={ __( '幅設定', THEME_NAME ) }>
+      <ButtonGroup aria-label={ __( '幅', THEME_NAME ) }>
+        { [ '25', '50', '75', '100' ].map( ( widthValue ) => {
+          return (
+            <Button
+              key={ widthValue }
+              isSmall
+              isPrimary={ widthValue === selectedWidth }
+              onClick={ () => handleChange( widthValue ) }
+            >
+              { widthValue }%
+            </Button>
+          );
+        } ) }
+      </ButtonGroup>
+    </PanelBody>
+  );
+}

--- a/blocks/src/components/index.js
+++ b/blocks/src/components/index.js
@@ -1,0 +1,1 @@
+export { default as WidthPanel } from './WidthPanel';


### PR DESCRIPTION
WidthPanelをcomponent化し、囲みボタンにも適用しました。

フォルダの場所や名称は適宜変更をお願いいたします。