### PR TITLE
プレビュー画面にアイコンが表示されるよう設定

### DIFF
--- a/blocks/src/init.php
+++ b/blocks/src/init.php
@@ -46,6 +46,7 @@ function cocoon_blocks_cgb_block_assets()
 	);
 
 	//Font Awesome
+	wp_enqueue_style_font_awesome();
 	if (apply_filters('cocoon_blocks_wp_enqueue_script_fontawesome', true)) {
 		//これを読み込んでおかないと以下のブロック等のアイコンが表示されなくなる
     // ・白抜ボックス


### PR DESCRIPTION
issue https://github.com/xserver-inc/cocoon/issues/86

プレビュー画面でfont-awesomeが読み込まれていなかったので、
ブロック表示時にスタイルを読み込むよう追記