### PR TITLE
エディターにサイトフォントを設定したスタイルを適応

### DIFF
--- a/blocks/src/init.php
+++ b/blocks/src/init.php
@@ -68,6 +68,17 @@ function cocoon_blocks_cgb_block_assets()
 			true
 		);
 	}
+
+  //Google Fonts
+  wp_enqueue_google_fonts();
+
+  //サイトフォントの設定を反映するクラスを付与
+  add_filter( 'admin_body_class', function($classes){
+    $classes .= ' wp-admin-'.get_site_font_family_class();
+    $classes .= ' wp-admin-'.get_site_font_size_class();
+    $classes .= ' wp-admin-'.get_site_font_weight_class();
+    return $classes;
+  });
 }
 
 /**

--- a/css/gutenberg-editor.css
+++ b/css/gutenberg-editor.css
@@ -598,6 +598,297 @@
   content: '\f1b0';
 }
 
+.fz-12px {
+  font-size: 12px;
+}
+
+.wp-admin-fz-12px .editor-styles-wrapper {
+  font-size: 12px;
+}
+
+.fz-13px {
+  font-size: 13px;
+}
+
+.wp-admin-fz-13px .editor-styles-wrapper {
+  font-size: 13px;
+}
+
+.fz-14px {
+  font-size: 14px;
+}
+
+.wp-admin-fz-14px .editor-styles-wrapper {
+  font-size: 14px;
+}
+
+.fz-15px {
+  font-size: 15px;
+}
+
+.wp-admin-fz-15px .editor-styles-wrapper {
+  font-size: 15px;
+}
+
+.fz-16px {
+  font-size: 16px;
+}
+
+.wp-admin-fz-16px .editor-styles-wrapper {
+  font-size: 16px;
+}
+
+.fz-17px {
+  font-size: 17px;
+}
+
+.wp-admin-fz-17px .editor-styles-wrapper {
+  font-size: 17px;
+}
+
+.fz-18px {
+  font-size: 18px;
+}
+
+.wp-admin-fz-18px .editor-styles-wrapper {
+  font-size: 18px;
+}
+
+.fz-19px {
+  font-size: 19px;
+}
+
+.wp-admin-fz-19px .editor-styles-wrapper {
+  font-size: 19px;
+}
+
+.fz-20px {
+  font-size: 20px;
+}
+
+.wp-admin-fz-20px .editor-styles-wrapper {
+  font-size: 20px;
+}
+
+.fz-21px {
+  font-size: 21px;
+}
+
+.wp-admin-fz-21px .editor-styles-wrapper {
+  font-size: 21px;
+}
+
+.fz-22px {
+  font-size: 22px;
+}
+
+.wp-admin-fz-22px .editor-styles-wrapper {
+  font-size: 22px;
+}
+
+.fz-24px {
+  font-size: 24px;
+}
+
+.wp-admin-fz-24px .editor-styles-wrapper {
+  font-size: 24px;
+}
+
+.fz-28px {
+  font-size: 28px;
+}
+
+.wp-admin-fz-28px .editor-styles-wrapper {
+  font-size: 28px;
+}
+
+.fz-32px {
+  font-size: 32px;
+}
+
+.wp-admin-fz-32px .editor-styles-wrapper {
+  font-size: 32px;
+}
+
+.fz-36px {
+  font-size: 36px;
+}
+
+.wp-admin-fz-36px .editor-styles-wrapper {
+  font-size: 36px;
+}
+
+.fz-40px {
+  font-size: 40px;
+}
+
+.wp-admin-fz-40px .editor-styles-wrapper {
+  font-size: 40px;
+}
+
+.fz-44px {
+  font-size: 44px;
+}
+
+.wp-admin-fz-44px .editor-styles-wrapper {
+  font-size: 44px;
+}
+
+.fz-48px {
+  font-size: 48px;
+}
+
+.wp-admin-fz-48px .editor-styles-wrapper {
+  font-size: 48px;
+}
+
+.fw-100 {
+  font-weight: 100;
+}
+
+.wp-admin-fw-100 .editor-styles-wrapper {
+  font-weight: 100;
+}
+
+.fw-200 {
+  font-weight: 200;
+}
+
+.wp-admin-fw-200 .editor-styles-wrapper {
+  font-weight: 200;
+}
+
+.fw-300 {
+  font-weight: 300;
+}
+
+.wp-admin-fw-300 .editor-styles-wrapper {
+  font-weight: 300;
+}
+
+.fw-400 {
+  font-weight: 400;
+}
+
+.wp-admin-fw-400 .editor-styles-wrapper {
+  font-weight: 400;
+}
+
+.fw-500 {
+  font-weight: 500;
+}
+
+.wp-admin-fw-500 .editor-styles-wrapper {
+  font-weight: 500;
+}
+
+.fw-600 {
+  font-weight: 600;
+}
+
+.wp-admin-fw-600 .editor-styles-wrapper {
+  font-weight: 600;
+}
+
+.fw-700 {
+  font-weight: 700;
+}
+
+.wp-admin-fw-700 .editor-styles-wrapper {
+  font-weight: 700;
+}
+
+.fw-800 {
+  font-weight: 800;
+}
+
+.wp-admin-fw-800 .editor-styles-wrapper {
+  font-weight: 800;
+}
+
+.fw-900 {
+  font-weight: 900;
+}
+
+.wp-admin-fw-900 .editor-styles-wrapper {
+  font-weight: 900;
+}
+
+.ff-meiryo,
+.wf-loading body,
+.wp-admin-ff-meiryo .editor-styles-wrapper {
+  font-family: Meiryo, "Hiragino Kaku Gothic ProN", "Hiragino Sans", sans-serif;
+}
+
+.ff-yu-gothic,
+.wp-admin-ff-yu-gothic .editor-styles-wrapper {
+  font-family: "Yu Gothic", Meiryo, "Hiragino Kaku Gothic ProN", "Hiragino Sans", sans-serif;
+}
+
+.ff-ms-pgothic,
+.wp-admin-ff-ms-pgothic .editor-styles-wrapper {
+  font-family: "MS PGothic", "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
+}
+
+.ff-noto-sans-jp,
+.wf-active .ff-noto-sans-jp,
+.wp-admin-ff-noto-sans-jp .editor-styles-wrapper {
+  font-family: "Noto Sans JP" ,sans-serif;
+}
+
+.ff-noto-serif-jp,
+.wf-active .ff-noto-serif-jp,
+.wp-admin-ff-noto-serif-jp .editor-styles-wrapper {
+  font-family: "Noto Serif JP" ,sans-serif;
+}
+
+.ff-mplus-1p,
+.wf-active .ff-mplus-1p,
+.wp-admin-ff-mplus-1p .editor-styles-wrapper {
+  font-family: "M PLUS 1p" ,sans-serif;
+}
+
+.ff-rounded-mplus-1c,
+.wf-active .ff-rounded-mplus-1c,
+.wp-admin-ff-rounded-mplus-1c .editor-styles-wrapper {
+  font-family: "M PLUS Rounded 1c" ,sans-serif;
+}
+
+.ff-kosugi,
+.wf-active .ff-kosugi,
+.wp-admin-ff-kosugi .editor-styles-wrapper {
+  font-family: "Kosugi" ,sans-serif;
+}
+
+.ff-kosugi-maru,
+.wf-active .ff-kosugi-maru,
+.wp-admin-ff-kosugi-maru .editor-styles-wrapper {
+  font-family: "Kosugi Maru" ,sans-serif;
+}
+
+.ff-sawarabi-gothic,
+.wf-active .ff-sawarabi-gothic,
+.wp-admin-ff-sawarabi-gothic .editor-styles-wrapper {
+  font-family: "Sawarabi Gothic" ,sans-serif;
+}
+
+.ff-sawarabi-mincho,
+.wf-active .ff-sawarabi-mincho,
+.wp-admin-ff-sawarabi-mincho .editor-styles-wrapper {
+  font-family: "Sawarabi Mincho" ,sans-serif;
+}
+
+.sub-caption {
+  font-family: Tunga, "Trebuchet MS", Tahoma, Verdana, "Segoe UI", var(--cocoon-default-font);
+  font-weight: 400;
+  font-size: 0.75em;
+  opacity: 0.5;
+}
+
+span.sub-caption {
+  opacity: 0.8;
+}
+
 .has-box-style {
   padding: var(--cocoon-box-padding);
 }
@@ -5096,11 +5387,6 @@ ol, ul {
 
 .speech-wrap .components-button {
   height: auto;
-}
-
-.body,
-.body p {
-  font-size: 18px;
 }
 
 .block-editor-editor-skeleton__body .editor-post-title {

--- a/lib/settings.php
+++ b/lib/settings.php
@@ -150,6 +150,12 @@ function visual_editor_stylesheets_custom($stylesheets) {
         add_file_ver_to_css_js(get_stylesheet_directory_uri().'/editor-style.css')
       );
     }
+    // fontの指定がgoogle fontの場合
+    if ( ! is_site_font_family_local() ) {
+        array_push($stylesheets,
+            add_file_ver_to_css_js( get_site_font_source_url() ),
+        );
+    }
   }
 
   //_v($stylesheets);
@@ -191,10 +197,6 @@ function gutenberg_stylesheets_custom() {
           !is_exclude_skin(get_skin_url(), get_editor_exclude_skins())) {
         wp_enqueue_style( THEME_NAME . '-skin-style', get_skin_url() );
       }
-
-      //カスタムスタイル
-      $cache_file_url = get_theme_css_cache_file_url();
-      wp_enqueue_style( THEME_NAME . '-css-cache-style', $cache_file_url );
 
       //子テーマがある場合
       if (is_child_theme()) {
@@ -257,7 +259,7 @@ function gutenberg_editor_settings( $editor_settings, $post ) {
       $path = url_to_local( $item );
       if ( empty( $path ) ) {
         $response = wp_remote_get( $item );
-        if ( ! is_wp_error( $response ) ) {
+        if ( ! is_wp_error( $response ) && wp_remote_retrieve_response_code( $response ) === 200 ) {
           $styles[] = array(
             'css' => wp_remote_retrieve_body( $response ),
           );

--- a/scss/_font.scss
+++ b/scss/_font.scss
@@ -8,11 +8,13 @@
 //フォントサイズ
 @for $i from 12 through 22 {
   .fz-#{$i}px { font-size: #{$i}px; }
+  .wp-admin-fz-#{$i}px .editor-styles-wrapper { font-size: #{$i}px; }
 }
 
 $i: 24;
 @while $i <= 48 {
   .fz-#{$i}px { font-size: #{$i}px; }
+  .wp-admin-fz-#{$i}px .editor-styles-wrapper { font-size: #{$i}px; }
   $i: $i + 4;
 }
 // @for $i from 24 through 36 {
@@ -23,45 +25,55 @@ $i: 24;
 //フォントウエイト
 @for $i from 1 through 9 {
   .fw-#{$i*100} { font-weight: #{$i*100}; }
+  .wp-admin-fw-#{$i*100} .editor-styles-wrapper { font-weight: #{$i*100}; }
 }
 
 //フォントファミリー
 .ff-meiryo,
-.wf-loading body{
+.wf-loading body,
+.wp-admin-ff-meiryo .editor-styles-wrapper {
   font-family: Meiryo, "Hiragino Kaku Gothic ProN", "Hiragino Sans", sans-serif;
 }
-.ff-yu-gothic{
+.ff-yu-gothic,
+.wp-admin-ff-yu-gothic .editor-styles-wrapper {
   font-family: "Yu Gothic", Meiryo, "Hiragino Kaku Gothic ProN", "Hiragino Sans", sans-serif;
 }
 // .ff-hiragino{
 //   font-family: "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
 // }
-.ff-ms-pgothic{
+.ff-ms-pgothic,
+.wp-admin-ff-ms-pgothic .editor-styles-wrapper {
   font-family: "MS PGothic", "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
 }
 
 .ff-noto-sans-jp,
-.wf-active .ff-noto-sans-jp{
+.wf-active .ff-noto-sans-jp,
+.wp-admin-ff-noto-sans-jp .editor-styles-wrapper {
   font-family: "Noto Sans JP" ,sans-serif;
 }
 .ff-noto-serif-jp,
-.wf-active .ff-noto-serif-jp{
+.wf-active .ff-noto-serif-jp,
+.wp-admin-ff-noto-serif-jp .editor-styles-wrapper {
   font-family: "Noto Serif JP" ,sans-serif;
 }
 .ff-mplus-1p,
-.wf-active .ff-mplus-1p{
+.wf-active .ff-mplus-1p,
+.wp-admin-ff-mplus-1p .editor-styles-wrapper {
   font-family: "M PLUS 1p" ,sans-serif;
 }
 .ff-rounded-mplus-1c,
-.wf-active .ff-rounded-mplus-1c{
+.wf-active .ff-rounded-mplus-1c,
+.wp-admin-ff-rounded-mplus-1c .editor-styles-wrapper {
   font-family: "M PLUS Rounded 1c" ,sans-serif;
 }
 .ff-kosugi,
-.wf-active .ff-kosugi{
+.wf-active .ff-kosugi,
+.wp-admin-ff-kosugi .editor-styles-wrapper {
   font-family: "Kosugi" ,sans-serif;
 }
 .ff-kosugi-maru,
-.wf-active .ff-kosugi-maru{
+.wf-active .ff-kosugi-maru,
+.wp-admin-ff-kosugi-maru .editor-styles-wrapper {
   font-family: "Kosugi Maru" ,sans-serif;
 }
 // .ff-hannari,
@@ -73,11 +85,13 @@ $i: 24;
 //   font-family: "Kokoro" ,sans-serif;
 // }
 .ff-sawarabi-gothic,
-.wf-active .ff-sawarabi-gothic{
+.wf-active .ff-sawarabi-gothic,
+.wp-admin-ff-sawarabi-gothic .editor-styles-wrapper {
   font-family: "Sawarabi Gothic" ,sans-serif;
 }
 .ff-sawarabi-mincho,
-.wf-active .ff-sawarabi-mincho{
+.wf-active .ff-sawarabi-mincho,
+.wp-admin-ff-sawarabi-mincho .editor-styles-wrapper {
   font-family: "Sawarabi Mincho" ,sans-serif;
 }
 

--- a/scss/gutenberg-editor.scss
+++ b/scss/gutenberg-editor.scss
@@ -13,6 +13,9 @@
 //Font Awesomeのアイコン
 @import "fontawesome-before";
 
+//フォントの設定
+@import "font";
+
 //エディタースタイル
 @import "extension";
 @import "extension-layout";
@@ -782,11 +785,6 @@ ol, ul {
 //WordPress 5.4からの吹き出しの不具合対応
 .speech-wrap .components-button{
   height: auto;
-}
-
-.body,
-.body p{
-  font-size: 18px;
 }
 
 //ブロックエディタータイトル余白の修正


### PR DESCRIPTION
「cocoon設定＞全体」にあるサイトフォントの設定をエディターにも適応されるようにしました。
gutenberg、クラシック両方に対応しています。
また、「cocoon設定＞エディター」にある「エディターにテーマスタイルを反映させる」を無効にすると
適応されないようになっています。


▼フォーラム
https://wp-cocoon.com/community/postid/74971/