### PR TITLE
Fix duplicated border class

### DIFF
--- a/blocks/src/block-extension/style-extension/style01.js
+++ b/blocks/src/block-extension/style-extension/style01.js
@@ -353,18 +353,15 @@ addFilter(
 const addCustomSave = ( props, blockType, attributes ) => {
   if ( allowedBlocks.includes( blockType.name ) ) {
     const { className } = props;
-    const { extraStyle, extraBorder } = attributes;
+    const { extraStyle } = attributes;
 
-    if ( className || extraStyle || extraBorder ) {
+    if ( className || extraStyle ) {
       props.className = classnames( {
         [ className ]: !! className,
         [ 'is-style-' + extraStyle ]: !! extraStyle,
-        [ 'is-style-' + extraBorder ]: !! extraBorder,
-        [ 'has-border' ]: extraBorder,
         [ 'has-box-style' ]: extraStyle,
       } );
     }
-
 
     return Object.assign( props );
   }


### PR DESCRIPTION
以下のフォーラムで指摘のあった不具合の修正
https://wp-cocoon.com/community/postid/75016/

段落のスタイルに適用しているソースにボーダーの記述が残っていました。

修正後、クラスの二重出力はなくなっています。
![image](https://github.com/xserver-inc/cocoon/assets/12522500/4b989d4a-6f70-4bcd-b281-fed5fc19c842)
