### PR TITLE
:sparkles: Disable lock feature from timeline block UI

### DIFF
--- a/blocks/src/block/timeline-item/block.json
+++ b/blocks/src/block/timeline-item/block.json
@@ -14,11 +14,10 @@
       "default": "タイトル"
     }
   },
-  "supports": {
-    "inserter": false
-  },
   "example": {},
   "supports": {
-    "anchor": true
+    "anchor": true,
+    "inserter": false,
+    "lock": false
   }
 }


### PR DESCRIPTION
フォーラムで報告されていた不具合の解消です。
https://wp-cocoon.com/community/postid/77043/

timeline-itemにフォーカスを当てた際のlock機能のUIを無効化しました。
![image](https://github.com/xserver-inc/cocoon/assets/12522500/4986a737-d696-4eaa-a136-350a4f1e1aec)

アイテム数の操作はサイドパネルからのみとなります。