### PR TITLE
grayishスキンのアップデート v1.1.0

### DIFF
--- a/skins/skin-grayish-topfull/style.css
+++ b/skins/skin-grayish-topfull/style.css
@@ -7,7 +7,7 @@
   Author: Na2factory
   Author URI: https://na2-factory.com/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-grayish-topfull.webp
-  Version: 1.0.13
+  Version: 1.1.0
   Priority: 7000001000
   License: GNU General Public License
   License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
ユーザーさんから要望もあり、v1.1.0で以下の機能追加を行いたいと思います。

1. PC時のフロントページ以外のヘッダーロゴをカスタマイザーで設定した画像に変更可能
　カスタマイザーの設定場所：フロントページ以外の設定：ヘッダー
2. モバイル時のヘッダーロゴをカスタマイザーで設定した画像に変更可能
    カスタマイザーの設定場所：モバイル設定の一番下

以下デモサイトで使用しています。
https://cocoon-grayish.na2-factory.com/grayish-salada-bar/

現状フロントページに正方形などのヘッダーロゴを設定した場合、
PC時のフロント以外のページや、モバイル時のヘッダーロゴが小さく微妙な見た目になります。
別に横長の画像を用意して設定したい、というご要望に応えたいと思います。

よろしくお願いいたします。