### PR TITLE
grayishスキンのアップデート v1.1.3

### DIFF
--- a/skins/skin-grayish-topfull/functions.php
+++ b/skins/skin-grayish-topfull/functions.php
@@ -2208,7 +2208,7 @@ if (!function_exists('mobile_header_buttons_set')) :
           }
         }
       </script>
-<?php
+    <?php
     }
   }
 endif;
@@ -2292,3 +2292,54 @@ add_filter("cocoon_part__tmp/mobile-logo-button", function ($content) {
   }
   return $content;
 });
+
+// pagination for large-number
+add_action(
+  "cocoon_part_after__tmp/pagination",
+  "replace_pagination_large_number"
+);
+
+if (!function_exists('replace_pagination_large_number')) :
+  function replace_pagination_large_number()
+  {
+    ?>
+    <script>
+      // v1.1.3 add for pagination large number
+      const pageNumbers = document.querySelectorAll('.page-numbers');
+
+      if (pageNumbers.length > 0) {
+        pageNumbers.forEach(function(pageNumber) {
+          // prev or next skip
+          if (pageNumber.classList.contains('prev') || pageNumber.classList.contains('next')) {
+            return;
+          }
+          const originalText = pageNumber.textContent;
+          const numberText = originalText.replace(/,/g, '');
+          // Set text with commas removed
+          pageNumber.textContent = numberText;
+          // Convert to integer (after removing commas)
+          const numberValue = parseInt(numberText, 10);
+          // For 4 digits, reduce font size
+          if (numberValue >= 1000) {
+            // Set original number as tooltip
+            pageNumber.setAttribute('title', numberText);
+            if (numberValue < 10000) {
+              pageNumber.style.fontSize = '0.8em';
+            } else if (numberValue < 1000000) {
+              // If 5 digits or more, abbreviated display
+              const shortenedText = (numberValue / 1000).toFixed(1) + 'K'; // ex: 12,345 -> 12.3K
+              pageNumber.textContent = shortenedText;
+              pageNumber.style.fontSize = '0.5em';
+            } else {
+              // For 6 digits or more
+              const shortenedText = (numberValue / 1000000).toFixed(1) + 'M'; // ex: 1,234,567 -> 1.2M
+              pageNumber.textContent = shortenedText;
+              pageNumber.style.fontSize = '0.5em';
+            }
+          }
+        });
+      }
+    </script>
+<?php
+  }
+endif;

--- a/skins/skin-grayish-topfull/javascript.js
+++ b/skins/skin-grayish-topfull/javascript.js
@@ -375,3 +375,5 @@ mediaQueryList1023.addEventListener('change', (e) => {
     }
   }
 });
+
+

--- a/skins/skin-grayish-topfull/style.css
+++ b/skins/skin-grayish-topfull/style.css
@@ -7,7 +7,7 @@
   Author: Na2factory
   Author URI: https://na2-factory.com/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-grayish-topfull.webp
-  Version: 1.1.2
+  Version: 1.1.3
   Priority: 7000001000
   License: GNU General Public License
   License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -168,6 +168,11 @@
 }
 
 /****************************** Common ******************************/
+/* v1.1.3 */
+*, :after, :before {
+  min-inline-size: 0
+}
+
 html {
   scroll-behavior: smooth;
   scroll-padding-top: 100px;
@@ -3450,13 +3455,24 @@ blockquote cite {
   scale: 1.1;
 }
 
+/* v1.1.3 */
 .skin-grayish .pagination .page-numbers,
 .skin-grayish .pager-links.pager-numbers .post-page-numbers .page-numbers {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  line-height: 1.7;
   background-color: var(--skin-grayish-gradient);
   border-radius: 99%;
   border: solid 1px var(--skin-grayish-gradient);
   letter-spacing: 0;
 }
+
+/* v1.1.3 */
+.skin-grayish .pager-links.pager-numbers .post-page-numbers {
+  text-decoration: none;
+}
+
 
 .skin-grayish .pagination .page-numbers.current,
 .skin-grayish .pager-links.pager-numbers .post-page-numbers .page-numbers.current {
@@ -3470,15 +3486,27 @@ blockquote cite {
   color: var(--skin-grayish-site-sub-color);
 }
 
-.skin-grayish.ff-noto-sans-jp .pagination .page-numbers,
+/* .skin-grayish.ff-noto-sans-jp .pagination .page-numbers,
 .skin-grayish.ff-noto-sans-jp .pager-links.pager-numbers .post-page-numbers .page-numbers {
   line-height: 43px;
-}
+} */
 
 /* ページネーション margin-bottom fronttyp:default & tab */
 .skin-grayish .pagination {
   margin: 24px 0 64px 0;
 }
+
+/* v1.1.3 */
+.skin-grayish .pagination {
+  flex-wrap: wrap;
+  row-gap: 1em;
+}
+
+.skin-grayish .pagination,
+.skin-grayish .pager-links.pager-numbers .post-page-numbers .page-numbers {
+  font-size: 16px;
+}
+
 
 /****************************** Footer  ******************************/
 .skin-grayish .footer {
@@ -4416,10 +4444,12 @@ blockquote cite {
   align-items: center;
   background-color: var(--skin-grayish-cat-back);
   width: 80px;
+  height: 80px;
   border-radius: 99%;
   top: calc(50% - 30px);
   left: unset;
   right: 20px;
+  padding: 10px 10px 10px 10px;
 }
 
 .skin-grayish .scroll-hint-icon:before,
@@ -4428,6 +4458,7 @@ blockquote cite {
 }
 
 .skin-grayish .scroll-hint-text {
+  font-size: 10px;
   color: var(--white);
   margin-top: 0;
 }
@@ -4714,6 +4745,28 @@ blockquote cite {
 /* for spotlight */
 body:has(#spotlight.show) .header {
   background-image: none;
+}
+
+/* v1.1.3 検索やinputのiOSズーム対応 投稿or固定ページ内の問い合わせフォームにも対応*/
+.search-box.input-box,
+.entry-content input[type="text"],
+.entry-content input[type="password"],
+.entry-content input[type="date"],
+.entry-content input[type="datetime"],
+.entry-content input[type="email"],
+.entry-content input[type="number"],
+.entry-content input[type="search"],
+.entry-content input[type="tel"],
+.entry-content input[type="time"],
+.entry-content input[type="url"],
+.entry-content textarea,
+.comment-area input,
+.comment-area textarea {
+  font-size: 16px;
+}
+
+.wp-block-search__input {
+  font-size: 16px !important;
 }
 
 
@@ -6481,9 +6534,15 @@ body:has(#spotlight.show) .header {
     padding: 0.4rem;
   }
 
-  .skin-grayish.ff-noto-sans-jp .pagination .page-numbers,
+  /* .skin-grayish.ff-noto-sans-jp .pagination .page-numbers,
   .skin-grayish.ff-noto-sans-jp .pager-links.pager-numbers .post-page-numbers .page-numbers {
     line-height: 31px;
+  } */
+
+  /* v1.1.3 */
+  .skin-grayish .pagination,
+  .skin-grayish .pager-links.pager-numbers .post-page-numbers .page-numbers {
+    font-size: 14px;
   }
 
 


### PR DESCRIPTION
paginationの不具合修正など

【pagination不具合内容】
1.SP時(画面幅480px以下）、記事一覧のページ数の表示数が多くなった時、記事一覧下のpaginationの数字を囲む円の表示が歪みます。
2.PC/SPどちらも、ページ数が1000以上になって4桁以上の表示になる際に、数字に折り返しやカンマが入って表示が乱れてしまいます。

【pagination修正内容】
1.ページ数の表示数が多くなったらpaginationを折り返しするように変更
2.ページ数が1000以上になって4桁以上の表示になる際には、カンマが入らないように整形し、フォントサイズを小さくして折り返し表示しないように対応
3.念の為、ページ数が5桁以上の表示になる際には、”K”を使った短縮表示で対応

【スクロールヒントCSS修正】
Cocoon ver2.7.8.1でスクロールヒントのCSSが修正されたことへのスキン独自表示の対応

【iOS対応追加 】
iPhoneやiPadでは、検索ボックスなどのinputタグの入力フォームのフォントサイズが16px未満だと
ユーザーが入力しようとタップした際にズームアップされてしまい、横スクロール状態になってしまいます。
この対策として検索ボックスと、投稿や固定ページに作られるお問い合わせフォーム等のinputタグについては、
フォントサイズ16pxを設定します。
