### PR TITLE
grayishスキンのアップデート v1.1.5

### DIFF
--- a/skins/skin-grayish-topfull/style.css
+++ b/skins/skin-grayish-topfull/style.css
@@ -7,7 +7,7 @@
   Author: Na2factory
   Author URI: https://na2-factory.com/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-grayish-topfull.webp
-  Version: 1.1.4
+  Version: 1.1.5
   Priority: 7000001000
   License: GNU General Public License
   License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -2792,6 +2792,7 @@ blockquote cite {
   border-top-right-radius: 0px;
   padding: 0.8em 1.5em;
   position: relative;
+  flex: 0 0 auto;
 }
 
 .tab-content-group {


### PR DESCRIPTION
お世話になっております。

grayish v1.1.3で追加したCSS
https://github.com/xserver-inc/cocoon/blob/fc94341f656cac1c979c04f88b546cb9caa96a57/skins/skin-grayish-topfull/style.css#L172
の影響により、タブブロックのタブ数が多い場合に表示が崩れてしまいましたので
修正させてください。

表示の崩れている様子はgrayishマニュアルのタブスタイル見本で確認可能です。
https://cocoon-grayish.na2-factory.com/cocoon-tabblk-style/#toc7

大変申し訳ありません。よろしくお願いいたします。
