### PR TITLE
grayishスキンのアップデート v2.0.0

### DIFF
--- a/skins/skin-grayish-topfull/functions.php
+++ b/skins/skin-grayish-topfull/functions.php
@@ -155,9 +155,35 @@ endif;
 if (!function_exists('enqueue_skin_grayish_google_fonts')) :
   function enqueue_skin_grayish_google_fonts()
   {
-    if (get_theme_mod('font_pat_control_radio', 'font_Montserrat') !== 'font_none') {
-      wp_enqueue_style('skin_grayish-google-fonts', 'https://fonts.googleapis.com/css?family=Roboto+Slab:200,400|Spectral:200,400|Inknut+Antiqua:300,400|Jost:300,400|Lato:300,400|Lora|Montserrat:200,400&display=swap');
+    // 手書きノートの修正方法に合わせる
+    $font_family = get_theme_mod('font_pat_control_radio', 'font_Montserrat');
+    $font_url = generate_font_url($font_family);
+    if ($font_family !== 'font_none') {
+      // 参考:https://www.tak-dcxi.com/article/optimization-of-google-font-loading/
+      echo '<link href="' . esc_url($font_url) . '" rel="preload" as="style" fetchpriority="high">' . "\n";
+      echo '<link href="' . esc_url($font_url) . '" rel="stylesheet" media="print" onload="this.media=\'all\'">' . "\n";
     }
+  }
+endif;
+
+// フォントのURLを生成する関数()
+if (!function_exists('generate_font_url')) :
+  function generate_font_url($font_family)
+  {
+    $font_families = array(
+      'font_Montserrat' => 'Montserrat:ital,wght@0,100..900;1,100..900&display=swap',
+      'font_Lato' => 'Lato:wght@300;400;700;900&display=swap',
+      'font_InknutAntiqua' => 'Inknut+Antiqua:wght@400;700;900&display=swap',
+      'font_Spectral' => 'Spectral:wght@200;400;600;800&display=swap',
+      'font_Lora' => 'Lora:ital,wght@0,400..700;1,400..700&display=swap',
+      'font_Jost' => 'Jost:ital,wght@0,100..900;1,100..900&display=swap',
+      'font_RobotoSlab' => 'Roboto+Slab:wght@100..900&display=swap',
+      'font_none' => '', // 読み込むフォントがない場合は空文字にする
+    );
+    if (isset($font_families[$font_family]) && $font_family !== 'font_none') {
+      return 'https://fonts.googleapis.com/css2?family=' . $font_families[$font_family];
+    }
+    return ''; // 該当するフォントが見つからない場合も空文字にする
   }
 endif;
 
@@ -275,7 +301,8 @@ if (!function_exists('skin_grayish_font_css')) :
     } elseif (get_theme_mod('font_pat_control_radio', 'font_Montserrat') === 'font_RobotoSlab') {
       $style_font = '"Roboto Slab", ' . $cocoon_site_font . ', var(--skin-grayish-default-font),sans-serif';
     } else {
-      $style_font = 'inherit';
+      // $style_font = 'inherit';
+      $style_font = $cocoon_site_font . ', var(--skin-grayish-default-font),sans-serif';
     }
     echo sprintf($style_template, $style_font);
     // CSS変数で出力
@@ -316,7 +343,8 @@ if (!function_exists('skin_grayish_font_blkeditor')) :
     } elseif (get_theme_mod('font_pat_control_radio', 'font_Montserrat') === 'font_RobotoSlab') {
       $style_font = '"Roboto Slab", ' . $cocoon_site_font . ', var(--skin-grayish-default-font),sans-serif';
     } else {
-      $style_font = 'inherit';
+      // $style_font = 'inherit';
+      $style_font = $cocoon_site_font . ', var(--skin-grayish-default-font),sans-serif';
     }
     // echo sprintf($style_template, $style_font);
     $style_fontfamily = sprintf($style_template, $style_font);
@@ -2294,3 +2322,181 @@ add_filter("cocoon_part__tmp/mobile-logo-button", function ($content) {
   }
   return $content;
 });
+
+// Cocoonのブロックなどのスタイル追加　silk参照
+class grayish_Custom_Functions
+{
+  // インスタンス保持
+  public static $instance = false;
+
+  // カスタムブロックスタイル（タブブロック）
+  const TAB_BLOCK_STYLES = [
+    // ここにカスタムスタイルを追加
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-up-line',
+        'label' => '上線',
+      ]
+    ],
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-tablabel',
+        'label' => 'カラーラベル'
+      ]
+    ],
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-line',
+        'label' => 'ライン'
+      ]
+    ],
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-cir',
+        'label' => '円'
+      ]
+    ],
+    // 均等配置
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-low-line-equal',
+        'label' => '均等デフォルト',
+      ]
+    ],
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-up-line-equal',
+        'label' => '均等上線',
+      ]
+    ],
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-tablabel-equal',
+        'label' => '均等カラーラベル'
+      ]
+    ],
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-line-equal',
+        'label' => '均等ライン'
+      ]
+    ],
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-cir-equal',
+        'label' => '均等円'
+      ]
+    ],
+    // 均等配置+PC時のみ中央寄りタイプ
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-low-line-equal-pc',
+        'label' => 'PC均等デフォルト',
+      ]
+    ],
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-up-line-equal-pc',
+        'label' => 'PC均等上線',
+      ]
+    ],
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-tablabel-equal-pc',
+        'label' => 'PC均等カラーラベル'
+      ]
+    ],
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-line-equal-pc',
+        'label' => 'PC均等ライン'
+      ]
+    ],
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-cir-equal-pc',
+        'label' => 'PC均等円'
+      ]
+    ],
+    // 均等配置+３の倍数タイプ
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-low-line-equal-odd',
+        'label' => '3-均等デフォルト',
+      ]
+    ],
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-up-line-equal-odd',
+        'label' => '3-均等上線',
+      ]
+    ],
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-tablabel-equal-odd',
+        'label' => '3-均等カラーラベル'
+      ]
+    ],
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-line-equal-odd',
+        'label' => '3-均等ライン'
+      ]
+    ],
+    [
+      'name'       => 'cocoon-blocks/tab',
+      'properties' => [
+        'name'  => 'grytab-cir-equal-odd',
+        'label' => '3-均等円'
+      ]
+    ]
+
+  ];
+
+  private function __construct()
+  {
+    add_action('after_setup_theme', [$this, 'setup_skin']);
+  }
+
+  public function setup_skin()
+  {
+    if (is_gutenberg_editor_enable()) {
+
+      // カスタムブロックスタイルの登録　
+      // フックcustom_grayish_block_stylesで別のブロックのスタイル追加も可能にする
+      $blockstyles = apply_filters('custom_grayish_block_styles', self::TAB_BLOCK_STYLES);
+      foreach ($blockstyles as $blockstyle) {
+        register_block_style($blockstyle['name'], $blockstyle['properties']);
+      }
+    }
+  }
+
+  // インスタンス生成
+  public static function instance()
+  {
+    if (!self::$instance) {
+      self::$instance = new self;
+    }
+    return self::$instance;
+  }
+}
+
+grayish_Custom_Functions::instance();

--- a/skins/skin-grayish-topfull/functions.php
+++ b/skins/skin-grayish-topfull/functions.php
@@ -155,35 +155,9 @@ endif;
 if (!function_exists('enqueue_skin_grayish_google_fonts')) :
   function enqueue_skin_grayish_google_fonts()
   {
-    // 手書きノートの修正方法に合わせる
-    $font_family = get_theme_mod('font_pat_control_radio', 'font_Montserrat');
-    $font_url = generate_font_url($font_family);
-    if ($font_family !== 'font_none') {
-      // 参考:https://www.tak-dcxi.com/article/optimization-of-google-font-loading/
-      echo '<link href="' . esc_url($font_url) . '" rel="preload" as="style" fetchpriority="high">' . "\n";
-      echo '<link href="' . esc_url($font_url) . '" rel="stylesheet" media="print" onload="this.media=\'all\'">' . "\n";
+    if (get_theme_mod('font_pat_control_radio', 'font_Montserrat') !== 'font_none') {
+      wp_enqueue_style('skin_grayish-google-fonts', 'https://fonts.googleapis.com/css?family=Roboto+Slab:200,400|Spectral:200,400|Inknut+Antiqua:300,400|Jost:300,400|Lato:300,400|Lora|Montserrat:200,400&display=swap');
     }
-  }
-endif;
-
-// フォントのURLを生成する関数()
-if (!function_exists('generate_font_url')) :
-  function generate_font_url($font_family)
-  {
-    $font_families = array(
-      'font_Montserrat' => 'Montserrat:ital,wght@0,100..900;1,100..900&display=swap',
-      'font_Lato' => 'Lato:wght@300;400;700;900&display=swap',
-      'font_InknutAntiqua' => 'Inknut+Antiqua:wght@400;700;900&display=swap',
-      'font_Spectral' => 'Spectral:wght@200;400;600;800&display=swap',
-      'font_Lora' => 'Lora:ital,wght@0,400..700;1,400..700&display=swap',
-      'font_Jost' => 'Jost:ital,wght@0,100..900;1,100..900&display=swap',
-      'font_RobotoSlab' => 'Roboto+Slab:wght@100..900&display=swap',
-      'font_none' => '', // 読み込むフォントがない場合は空文字にする
-    );
-    if (isset($font_families[$font_family]) && $font_family !== 'font_none') {
-      return 'https://fonts.googleapis.com/css2?family=' . $font_families[$font_family];
-    }
-    return ''; // 該当するフォントが見つからない場合も空文字にする
   }
 endif;
 
@@ -301,8 +275,7 @@ if (!function_exists('skin_grayish_font_css')) :
     } elseif (get_theme_mod('font_pat_control_radio', 'font_Montserrat') === 'font_RobotoSlab') {
       $style_font = '"Roboto Slab", ' . $cocoon_site_font . ', var(--skin-grayish-default-font),sans-serif';
     } else {
-      // $style_font = 'inherit';
-      $style_font = $cocoon_site_font . ', var(--skin-grayish-default-font),sans-serif';
+      $style_font = 'inherit';
     }
     echo sprintf($style_template, $style_font);
     // CSS変数で出力
@@ -343,8 +316,7 @@ if (!function_exists('skin_grayish_font_blkeditor')) :
     } elseif (get_theme_mod('font_pat_control_radio', 'font_Montserrat') === 'font_RobotoSlab') {
       $style_font = '"Roboto Slab", ' . $cocoon_site_font . ', var(--skin-grayish-default-font),sans-serif';
     } else {
-      // $style_font = 'inherit';
-      $style_font = $cocoon_site_font . ', var(--skin-grayish-default-font),sans-serif';
+      $style_font = 'inherit';
     }
     // echo sprintf($style_template, $style_font);
     $style_fontfamily = sprintf($style_template, $style_font);
@@ -2322,181 +2294,3 @@ add_filter("cocoon_part__tmp/mobile-logo-button", function ($content) {
   }
   return $content;
 });
-
-// Cocoonのブロックなどのスタイル追加　silk参照
-class grayish_Custom_Functions
-{
-  // インスタンス保持
-  public static $instance = false;
-
-  // カスタムブロックスタイル（タブブロック）
-  const TAB_BLOCK_STYLES = [
-    // ここにカスタムスタイルを追加
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-up-line',
-        'label' => '上線',
-      ]
-    ],
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-tablabel',
-        'label' => 'カラーラベル'
-      ]
-    ],
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-line',
-        'label' => 'ライン'
-      ]
-    ],
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-cir',
-        'label' => '円'
-      ]
-    ],
-    // 均等配置
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-low-line-equal',
-        'label' => '均等デフォルト',
-      ]
-    ],
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-up-line-equal',
-        'label' => '均等上線',
-      ]
-    ],
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-tablabel-equal',
-        'label' => '均等カラーラベル'
-      ]
-    ],
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-line-equal',
-        'label' => '均等ライン'
-      ]
-    ],
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-cir-equal',
-        'label' => '均等円'
-      ]
-    ],
-    // 均等配置+PC時のみ中央寄りタイプ
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-low-line-equal-pc',
-        'label' => 'PC均等デフォルト',
-      ]
-    ],
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-up-line-equal-pc',
-        'label' => 'PC均等上線',
-      ]
-    ],
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-tablabel-equal-pc',
-        'label' => 'PC均等カラーラベル'
-      ]
-    ],
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-line-equal-pc',
-        'label' => 'PC均等ライン'
-      ]
-    ],
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-cir-equal-pc',
-        'label' => 'PC均等円'
-      ]
-    ],
-    // 均等配置+３の倍数タイプ
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-low-line-equal-odd',
-        'label' => '3-均等デフォルト',
-      ]
-    ],
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-up-line-equal-odd',
-        'label' => '3-均等上線',
-      ]
-    ],
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-tablabel-equal-odd',
-        'label' => '3-均等カラーラベル'
-      ]
-    ],
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-line-equal-odd',
-        'label' => '3-均等ライン'
-      ]
-    ],
-    [
-      'name'       => 'cocoon-blocks/tab',
-      'properties' => [
-        'name'  => 'grytab-cir-equal-odd',
-        'label' => '3-均等円'
-      ]
-    ]
-
-  ];
-
-  private function __construct()
-  {
-    add_action('after_setup_theme', [$this, 'setup_skin']);
-  }
-
-  public function setup_skin()
-  {
-    if (is_gutenberg_editor_enable()) {
-
-      // カスタムブロックスタイルの登録　
-      // フックcustom_grayish_block_stylesで別のブロックのスタイル追加も可能にする
-      $blockstyles = apply_filters('custom_grayish_block_styles', self::TAB_BLOCK_STYLES);
-      foreach ($blockstyles as $blockstyle) {
-        register_block_style($blockstyle['name'], $blockstyle['properties']);
-      }
-    }
-  }
-
-  // インスタンス生成
-  public static function instance()
-  {
-    if (!self::$instance) {
-      self::$instance = new self;
-    }
-    return self::$instance;
-  }
-}
-
-grayish_Custom_Functions::instance();

--- a/skins/skin-grayish-topfull/style.css
+++ b/skins/skin-grayish-topfull/style.css
@@ -1,4 +1,5 @@
 @charset "UTF-8";
+
 /*!
   Skin Name: grayish
   Description: グレイベースのシンプルデザイン フロントページにメインビジュアルを画面高さいっぱいに表示するスキンです
@@ -6,7 +7,7 @@
   Author: Na2factory
   Author URI: https://na2-factory.com/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-grayish-topfull.webp
-  Version: 2.0.0
+  Version: 1.1.5
   Priority: 7000001000
   License: GNU General Public License
   License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -177,12 +178,9 @@ html {
   scroll-padding-top: 100px;
 }
 
-.body {
+.skin-grayish {
   letter-spacing: .16rem;
   font-feature-settings: 'palt';
-}
-
-.skin-grayish {
   overflow-x: hidden;
 }
 
@@ -2363,11 +2361,6 @@ dialog[open] .searchMenuDialog_close.grayish-btn {
   position: relative;
 }
 
-.blank-box.bb-tab .bb-label {
-  display: flex;
-  align-items: center;
-}
-
 .skin-grayish .blank-box.bb-tab .bb-label {
   background-color: var(--LtBlue_S30);
   position: absolute;
@@ -2846,13 +2839,13 @@ blockquote cite {
   bottom: 0;
 }
 
-/* [class*="gray-tab-style"] .tab-content-group {
+[class*="gray-tab-style"] .tab-content-group {
   border: none;
 }
 
 [class*="gray-tab-style"] .tab-label-group .tab-label::after {
   display: none;
-} */
+}
 
 /* オプション：１カラム フロントページ向け */
 /* オプション：フォントサイズ 16px -> 10pxへレスポンシブ */
@@ -2862,43 +2855,33 @@ blockquote cite {
 
 
 /* オプション：均等配置 ver */
-.gray-tab-label-equal:not([class*="is-style-grytab"]) .tab-label-group,
-:where(.is-style-grytab-low-line-equal, .is-style-grytab-up-line-equal, .is-style-grytab-tablabel-equal, .is-style-grytab-line-equal, .is-style-grytab-cir-equal) .tab-label-group,
-:where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group,
-:where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd) .tab-label-group {
+.gray-tab-label-equal .tab-label-group {
   justify-content: space-between;
   flex-wrap: wrap;
   overflow-wrap: anywhere;
   white-space: normal;
 }
 
-.gray-tab-label-equal:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
-:where(.is-style-grytab-low-line-equal, .is-style-grytab-up-line-equal, .is-style-grytab-tablabel-equal, .is-style-grytab-line-equal, .is-style-grytab-cir-equal) .tab-label-group .tab-label,
-:where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label {
+.gray-tab-label-equal .tab-label-group .tab-label {
   flex: 1;
   text-align: center;
 }
 
 /* オプション：均等配置 PC時のみセンター ver */
-.gray-tab-label-equal.--pc-center:not([class*="is-style-grytab"]) .tab-label-group,
-:where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group {
+.gray-tab-label-equal.--pc-center .tab-label-group {
   justify-content: center;
 }
 
-.gray-tab-label-equal.--pc-center:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
-:where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group .tab-label {
+.gray-tab-label-equal.--pc-center .tab-label-group .tab-label {
   flex: 0 0 25%;
-  text-align: center;
 }
 
 /* スタイル１：線 upper-type */
-.gray-tab-style-up:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active::after,
-:where(.is-style-grytab-up-line, .is-style-grytab-up-line-equal, .is-style-grytab-up-line-equal-pc, .is-style-grytab-up-line-equal-odd) .tab-label-group .tab-label.is-active::after {
+.gray-tab-style-up .tab-label-group .tab-label.is-active::after {
   background-color: var(--skin-grayish-site-main-hover);
 }
 
-.gray-tab-style-up:not([class*="is-style-grytab"]) .tab-label-group .tab-label::after,
-:where(.is-style-grytab-up-line, .is-style-grytab-up-line-equal, .is-style-grytab-up-line-equal-pc, .is-style-grytab-up-line-equal-odd) .tab-label-group .tab-label::after {
+.gray-tab-style-up .tab-label-group .tab-label::after {
   display: block;
   content: "";
   background-color: transparent;
@@ -2916,27 +2899,24 @@ blockquote cite {
 /* .gray-tab-style .tab-content-group {
   background-color: var(--LtBlue_T90);
 } */
-.gray-tab-style:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
-:where(.is-style-grytab-tablabel, .is-style-grytab-tablabel-equal, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-tablabel-equal-odd) .tab-label-group .tab-label {
+
+.gray-tab-style .tab-label-group .tab-label {
   padding: 0.5em 1.5em;
   background-color: var(--white);
   transition: background-color .4s;
 
 }
 
-.gray-tab-style:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active,
-:where(.is-style-grytab-tablabel, .is-style-grytab-tablabel-equal, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-tablabel-equal-odd) .tab-label-group .tab-label.is-active {
+.gray-tab-style .tab-label-group .tab-label.is-active {
   background-color: var(--LtBlue_T70);
   color: var(--LtGray_S50);
 }
 
-.gray-tab-style:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active::after,
-:where(.is-style-grytab-tablabel, .is-style-grytab-tablabel-equal, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-tablabel-equal-odd) .tab-label-group .tab-label.is-active::after {
+.gray-tab-style .tab-label-group .tab-label.is-active::after {
   background-color: var(--LtBlue_T0);
 }
 
-.gray-tab-style:not([class*="is-style-grytab"]) .tab-label-group .tab-label::after,
-:where(.is-style-grytab-tablabel, .is-style-grytab-tablabel-equal, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-tablabel-equal-odd) .tab-label-group .tab-label::after {
+.gray-tab-style .tab-label-group .tab-label::after {
   display: block;
   content: "";
   background-color: transparent;
@@ -2950,20 +2930,17 @@ blockquote cite {
 }
 
 /* スタイル3：ライン */
-.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-content-group,
-:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-content-group {
+.gray-tab-style-line .tab-content-group {
   border-top: 1px solid var(--LtGray_T70);
   border-bottom: 1px solid var(--LtGray_T70);
   background-color: var(--white);
 }
 
-.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group,
-:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group {
+.gray-tab-style-line .tab-label-group {
   padding-bottom: 0.5em;
 }
 
-.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
-:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label {
+.gray-tab-style-line .tab-label-group .tab-label {
   padding: 0.5em 1.5em;
   background-color: var(--white);
   color: var(--LtGray_T30);
@@ -2971,13 +2948,11 @@ blockquote cite {
 
 }
 
-.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active,
-:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label.is-active {
+.gray-tab-style-line .tab-label-group .tab-label.is-active {
   color: var(--LtGray_S50);
 }
 
-.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label::before,
-:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label::before {
+.gray-tab-style-line .tab-label-group .tab-label::before {
   display: block;
   content: "";
   background-color: var(--LtGray_T70);
@@ -2991,32 +2966,21 @@ blockquote cite {
 }
 
 
-.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label:first-child::before,
-:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label:first-child::before {
-  display: none;
-}
-
-.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active::after,
-:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label.is-active::after,
-.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label::after,
-:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label::after {
+.gray-tab-style-line .tab-label-group .tab-label:first-child::before {
   display: none;
 }
 
 /* スタイル4：ラベルの端が円タイプ */
-.gray-tab-style-cir:not([class*="is-style-grytab"]),
-:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) {
+.gray-tab-style-cir {
   background-color: var(--Blk_Beige_T70);
 }
 
-.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-content-group,
-:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-content-group {
+.gray-tab-style-cir .tab-content-group {
   border-top: 1px solid var(--Blk_Beige_T0);
   background-color: var(--Blk_Beige_T70);
 }
 
-.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-label-group,
-:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-label-group {
+.gray-tab-style-cir .tab-label-group {
   background-color: var(--Blk_Beige_T70);
   row-gap: 8px;
   -moz-column-gap: 4px;
@@ -3024,8 +2988,7 @@ blockquote cite {
   padding: 2em 1em;
 }
 
-.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
-:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label {
+.gray-tab-style-cir .tab-label-group .tab-label {
   padding: 0.5em 1.5em;
   background-color: var(--white);
   border-radius: 30px 30px;
@@ -3034,24 +2997,15 @@ blockquote cite {
   transition: background-color .4s, color .4s;
 }
 
-.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active,
-:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label.is-active {
+.gray-tab-style-cir .tab-label-group .tab-label.is-active {
   background-color: var(--Blk_Beige_S50);
   color: var(--white);
-}
-
-.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active::after,
-:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label.is-active::after,
-.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-label-group .tab-label::after,
-:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label::after {
-  display: none;
 }
 
 
 /* tab box for .nwa */
 /* even */
-.nwa .gray-tab-label-equal:not([class*="is-style-grytab"]) .tab-label-group,
-.nwa :where(.is-style-grytab-low-line-equal, .is-style-grytab-up-line-equal, .is-style-grytab-tablabel-equal, .is-style-grytab-line-equal, .is-style-grytab-cir-equal) .tab-label-group {
+.nwa .gray-tab-label-equal .tab-label-group {
   display: grid;
   grid-template-rows: auto;
   grid-template-columns: repeat(auto-fit, minmax(40%, 1fr));
@@ -3059,48 +3013,26 @@ blockquote cite {
 }
 
 /* odd (Max 3想定) */
-.nwa .gray-tab-label-equal.--odd:not([class*="is-style-grytab"]) .tab-label-group,
-.nwa :where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd) .tab-label-group {
+.nwa .gray-tab-label-equal.--odd .tab-label-group {
   display: grid;
   grid-template-rows: auto;
   grid-template-columns: repeat(auto-fit, minmax(30%, 1fr));
   row-gap: 4px;
 }
 
-.nwa .gray-tab-label-equal:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
-.nwa :where(.is-style-grytab-low-line-equal, .is-style-grytab-up-line-equal, .is-style-grytab-tablabel-equal, .is-style-grytab-line-equal, .is-style-grytab-cir-equal) .tab-label-group .tab-label,
-.nwa :where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group .tab-label,
-.nwa :where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label {
+.nwa .gray-tab-label-equal .tab-label-group .tab-label {
   font-size: 12px;
 }
 
 /* ラインタイプ　かつ even */
-.nwa .gray-tab-style-line.gray-tab-label-equal:not([class*="is-style-grytab"]):not(.--odd) .tab-label-group .tab-label:nth-child(odd)::before,
-.nwa :where(.is-style-grytab-line-equal, .is-style-grytab-line-equal-pc) .tab-label-group .tab-label:nth-child(odd)::before {
+.nwa .gray-tab-style-line.gray-tab-label-equal:not(.--odd) .tab-label-group .tab-label:nth-child(odd)::before {
   display: none;
 }
 
 /* ラインタイプ　かつ --odd */
-.nwa .gray-tab-style-line.gray-tab-label-equal:not([class*="is-style-grytab"]).--odd .tab-label-group .tab-label:nth-child(3n+1)::before,
-.nwa .is-style-grytab-line-equal-odd .tab-label-group .tab-label:nth-child(3n+1)::before {
+.nwa .gray-tab-style-line.gray-tab-label-equal.--odd .tab-label-group .tab-label:nth-child(3n+1)::before {
   display: none;
 }
-
-/* オプション：均等配置 PC時のみセンター ver はnwaに配置されたら even均等配置にする　*/
-.nwa .gray-tab-label-equal:not([class*="is-style-grytab"]).--pc-center .tab-label-group,
-.nwa :where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group {
-  display: grid;
-  grid-template-rows: auto;
-  grid-template-columns: repeat(auto-fit, minmax(40%, 1fr));
-  row-gap: 4px;
-}
-
-.nwa .gray-tab-label-equal:not([class*="is-style-grytab"]).--pc-center .tab-label-group .tab-label,
-.nwa :where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group .tab-label {
-  /* flex: 0 0 25%; */
-  text-align: center;
-}
-
 
 /* サイドバーpadding */
 .skin-grayish .sidebar-menu-content .sidebar.nwa {
@@ -3111,7 +3043,7 @@ blockquote cite {
   padding: 1.2em 0;
 }
 
-.nwa :is(.gray-tab-style-cir, .is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-content-group,
+.nwa .gray-tab-style-cir .tab-content-group,
 .nwa .footer-widgets .tab-content-group,
 .nwa .footer-widgets-mobile .tab-content-group {
   padding: 1.2em 0.8em;
@@ -5615,9 +5547,7 @@ body:has(#spotlight.show) .header {
 
   /* tab box for front */
   /* even */
-  .gray-tab-label-equal:not([class*="is-style-grytab"]).tab-block .tab-label-group,
-  :where(.is-style-grytab-low-line-equal, .is-style-grytab-up-line-equal, .is-style-grytab-tablabel-equal, .is-style-grytab-line-equal, .is-style-grytab-cir-equal).tab-block .tab-label-group,
-  :where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc).tab-block .tab-label-group {
+  .gray-tab-label-equal .tab-label-group {
     display: grid;
     grid-template-rows: auto;
     grid-template-columns: repeat(auto-fit, minmax(40%, 1fr));
@@ -5625,29 +5555,24 @@ body:has(#spotlight.show) .header {
   }
 
   /* odd (Max 3想定) */
-  .gray-tab-label-equal.--odd:not([class*="is-style-grytab"]) .tab-label-group,
-  :where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd).tab-block .tab-label-group {
+  .gray-tab-label-equal.--odd .tab-label-group {
     display: grid;
     grid-template-rows: auto;
     grid-template-columns: repeat(auto-fit, minmax(30%, 1fr));
     row-gap: 4px;
   }
 
-  .gray-tab-label-equal:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
-  :where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group .tab-label,
-  :where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label {
+  .gray-tab-label-equal .tab-label-group .tab-label {
     font-size: clamp(0.75rem, 0.6397rem + 0.3676vw, 0.875rem);
   }
 
   /* ラインタイプ　かつ even */
-  .gray-tab-style-line.gray-tab-label-equal:not(.--odd):not([class*="is-style-grytab"]) .tab-label-group .tab-label:nth-child(odd)::before,
-  :where(.is-style-grytab-line-equal, .is-style-grytab-line-equal-pc) .tab-label-group .tab-label:nth-child(odd)::before {
+  .gray-tab-style-line.gray-tab-label-equal:not(.--odd) .tab-label-group .tab-label:nth-child(odd)::before {
     display: none;
   }
 
   /* ラインタイプ　かつ --odd */
-  .gray-tab-style-line.gray-tab-label-equal.--odd:not([class*="is-style-grytab"]) .tab-label-group .tab-label:nth-child(3n+1)::before,
-  .is-style-grytab-line-equal-odd .tab-label-group .tab-label:nth-child(3n+1)::before {
+  .gray-tab-style-line.gray-tab-label-equal.--odd .tab-label-group .tab-label:nth-child(3n+1)::before {
     display: none;
   }
 

--- a/skins/skin-grayish-topfull/style.css
+++ b/skins/skin-grayish-topfull/style.css
@@ -1,5 +1,4 @@
 @charset "UTF-8";
-
 /*!
   Skin Name: grayish
   Description: グレイベースのシンプルデザイン フロントページにメインビジュアルを画面高さいっぱいに表示するスキンです
@@ -7,7 +6,7 @@
   Author: Na2factory
   Author URI: https://na2-factory.com/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-grayish-topfull.webp
-  Version: 1.1.5
+  Version: 2.0.0
   Priority: 7000001000
   License: GNU General Public License
   License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -178,9 +177,12 @@ html {
   scroll-padding-top: 100px;
 }
 
-.skin-grayish {
+.body {
   letter-spacing: .16rem;
   font-feature-settings: 'palt';
+}
+
+.skin-grayish {
   overflow-x: hidden;
 }
 
@@ -2361,6 +2363,11 @@ dialog[open] .searchMenuDialog_close.grayish-btn {
   position: relative;
 }
 
+.blank-box.bb-tab .bb-label {
+  display: flex;
+  align-items: center;
+}
+
 .skin-grayish .blank-box.bb-tab .bb-label {
   background-color: var(--LtBlue_S30);
   position: absolute;
@@ -2839,13 +2846,13 @@ blockquote cite {
   bottom: 0;
 }
 
-[class*="gray-tab-style"] .tab-content-group {
+/* [class*="gray-tab-style"] .tab-content-group {
   border: none;
 }
 
 [class*="gray-tab-style"] .tab-label-group .tab-label::after {
   display: none;
-}
+} */
 
 /* オプション：１カラム フロントページ向け */
 /* オプション：フォントサイズ 16px -> 10pxへレスポンシブ */
@@ -2855,33 +2862,43 @@ blockquote cite {
 
 
 /* オプション：均等配置 ver */
-.gray-tab-label-equal .tab-label-group {
+.gray-tab-label-equal:not([class*="is-style-grytab"]) .tab-label-group,
+:where(.is-style-grytab-low-line-equal, .is-style-grytab-up-line-equal, .is-style-grytab-tablabel-equal, .is-style-grytab-line-equal, .is-style-grytab-cir-equal) .tab-label-group,
+:where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group,
+:where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd) .tab-label-group {
   justify-content: space-between;
   flex-wrap: wrap;
   overflow-wrap: anywhere;
   white-space: normal;
 }
 
-.gray-tab-label-equal .tab-label-group .tab-label {
+.gray-tab-label-equal:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
+:where(.is-style-grytab-low-line-equal, .is-style-grytab-up-line-equal, .is-style-grytab-tablabel-equal, .is-style-grytab-line-equal, .is-style-grytab-cir-equal) .tab-label-group .tab-label,
+:where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label {
   flex: 1;
   text-align: center;
 }
 
 /* オプション：均等配置 PC時のみセンター ver */
-.gray-tab-label-equal.--pc-center .tab-label-group {
+.gray-tab-label-equal.--pc-center:not([class*="is-style-grytab"]) .tab-label-group,
+:where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group {
   justify-content: center;
 }
 
-.gray-tab-label-equal.--pc-center .tab-label-group .tab-label {
+.gray-tab-label-equal.--pc-center:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
+:where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group .tab-label {
   flex: 0 0 25%;
+  text-align: center;
 }
 
 /* スタイル１：線 upper-type */
-.gray-tab-style-up .tab-label-group .tab-label.is-active::after {
+.gray-tab-style-up:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active::after,
+:where(.is-style-grytab-up-line, .is-style-grytab-up-line-equal, .is-style-grytab-up-line-equal-pc, .is-style-grytab-up-line-equal-odd) .tab-label-group .tab-label.is-active::after {
   background-color: var(--skin-grayish-site-main-hover);
 }
 
-.gray-tab-style-up .tab-label-group .tab-label::after {
+.gray-tab-style-up:not([class*="is-style-grytab"]) .tab-label-group .tab-label::after,
+:where(.is-style-grytab-up-line, .is-style-grytab-up-line-equal, .is-style-grytab-up-line-equal-pc, .is-style-grytab-up-line-equal-odd) .tab-label-group .tab-label::after {
   display: block;
   content: "";
   background-color: transparent;
@@ -2899,24 +2916,27 @@ blockquote cite {
 /* .gray-tab-style .tab-content-group {
   background-color: var(--LtBlue_T90);
 } */
-
-.gray-tab-style .tab-label-group .tab-label {
+.gray-tab-style:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
+:where(.is-style-grytab-tablabel, .is-style-grytab-tablabel-equal, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-tablabel-equal-odd) .tab-label-group .tab-label {
   padding: 0.5em 1.5em;
   background-color: var(--white);
   transition: background-color .4s;
 
 }
 
-.gray-tab-style .tab-label-group .tab-label.is-active {
+.gray-tab-style:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active,
+:where(.is-style-grytab-tablabel, .is-style-grytab-tablabel-equal, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-tablabel-equal-odd) .tab-label-group .tab-label.is-active {
   background-color: var(--LtBlue_T70);
   color: var(--LtGray_S50);
 }
 
-.gray-tab-style .tab-label-group .tab-label.is-active::after {
+.gray-tab-style:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active::after,
+:where(.is-style-grytab-tablabel, .is-style-grytab-tablabel-equal, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-tablabel-equal-odd) .tab-label-group .tab-label.is-active::after {
   background-color: var(--LtBlue_T0);
 }
 
-.gray-tab-style .tab-label-group .tab-label::after {
+.gray-tab-style:not([class*="is-style-grytab"]) .tab-label-group .tab-label::after,
+:where(.is-style-grytab-tablabel, .is-style-grytab-tablabel-equal, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-tablabel-equal-odd) .tab-label-group .tab-label::after {
   display: block;
   content: "";
   background-color: transparent;
@@ -2930,17 +2950,20 @@ blockquote cite {
 }
 
 /* スタイル3：ライン */
-.gray-tab-style-line .tab-content-group {
+.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-content-group,
+:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-content-group {
   border-top: 1px solid var(--LtGray_T70);
   border-bottom: 1px solid var(--LtGray_T70);
   background-color: var(--white);
 }
 
-.gray-tab-style-line .tab-label-group {
+.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group,
+:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group {
   padding-bottom: 0.5em;
 }
 
-.gray-tab-style-line .tab-label-group .tab-label {
+.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
+:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label {
   padding: 0.5em 1.5em;
   background-color: var(--white);
   color: var(--LtGray_T30);
@@ -2948,11 +2971,13 @@ blockquote cite {
 
 }
 
-.gray-tab-style-line .tab-label-group .tab-label.is-active {
+.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active,
+:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label.is-active {
   color: var(--LtGray_S50);
 }
 
-.gray-tab-style-line .tab-label-group .tab-label::before {
+.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label::before,
+:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label::before {
   display: block;
   content: "";
   background-color: var(--LtGray_T70);
@@ -2966,21 +2991,32 @@ blockquote cite {
 }
 
 
-.gray-tab-style-line .tab-label-group .tab-label:first-child::before {
+.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label:first-child::before,
+:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label:first-child::before {
+  display: none;
+}
+
+.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active::after,
+:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label.is-active::after,
+.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label::after,
+:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label::after {
   display: none;
 }
 
 /* スタイル4：ラベルの端が円タイプ */
-.gray-tab-style-cir {
+.gray-tab-style-cir:not([class*="is-style-grytab"]),
+:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) {
   background-color: var(--Blk_Beige_T70);
 }
 
-.gray-tab-style-cir .tab-content-group {
+.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-content-group,
+:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-content-group {
   border-top: 1px solid var(--Blk_Beige_T0);
   background-color: var(--Blk_Beige_T70);
 }
 
-.gray-tab-style-cir .tab-label-group {
+.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-label-group,
+:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-label-group {
   background-color: var(--Blk_Beige_T70);
   row-gap: 8px;
   -moz-column-gap: 4px;
@@ -2988,7 +3024,8 @@ blockquote cite {
   padding: 2em 1em;
 }
 
-.gray-tab-style-cir .tab-label-group .tab-label {
+.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
+:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label {
   padding: 0.5em 1.5em;
   background-color: var(--white);
   border-radius: 30px 30px;
@@ -2997,15 +3034,24 @@ blockquote cite {
   transition: background-color .4s, color .4s;
 }
 
-.gray-tab-style-cir .tab-label-group .tab-label.is-active {
+.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active,
+:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label.is-active {
   background-color: var(--Blk_Beige_S50);
   color: var(--white);
+}
+
+.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active::after,
+:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label.is-active::after,
+.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-label-group .tab-label::after,
+:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label::after {
+  display: none;
 }
 
 
 /* tab box for .nwa */
 /* even */
-.nwa .gray-tab-label-equal .tab-label-group {
+.nwa .gray-tab-label-equal:not([class*="is-style-grytab"]) .tab-label-group,
+.nwa :where(.is-style-grytab-low-line-equal, .is-style-grytab-up-line-equal, .is-style-grytab-tablabel-equal, .is-style-grytab-line-equal, .is-style-grytab-cir-equal) .tab-label-group {
   display: grid;
   grid-template-rows: auto;
   grid-template-columns: repeat(auto-fit, minmax(40%, 1fr));
@@ -3013,26 +3059,48 @@ blockquote cite {
 }
 
 /* odd (Max 3想定) */
-.nwa .gray-tab-label-equal.--odd .tab-label-group {
+.nwa .gray-tab-label-equal.--odd:not([class*="is-style-grytab"]) .tab-label-group,
+.nwa :where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd) .tab-label-group {
   display: grid;
   grid-template-rows: auto;
   grid-template-columns: repeat(auto-fit, minmax(30%, 1fr));
   row-gap: 4px;
 }
 
-.nwa .gray-tab-label-equal .tab-label-group .tab-label {
+.nwa .gray-tab-label-equal:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
+.nwa :where(.is-style-grytab-low-line-equal, .is-style-grytab-up-line-equal, .is-style-grytab-tablabel-equal, .is-style-grytab-line-equal, .is-style-grytab-cir-equal) .tab-label-group .tab-label,
+.nwa :where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group .tab-label,
+.nwa :where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label {
   font-size: 12px;
 }
 
 /* ラインタイプ　かつ even */
-.nwa .gray-tab-style-line.gray-tab-label-equal:not(.--odd) .tab-label-group .tab-label:nth-child(odd)::before {
+.nwa .gray-tab-style-line.gray-tab-label-equal:not([class*="is-style-grytab"]):not(.--odd) .tab-label-group .tab-label:nth-child(odd)::before,
+.nwa :where(.is-style-grytab-line-equal, .is-style-grytab-line-equal-pc) .tab-label-group .tab-label:nth-child(odd)::before {
   display: none;
 }
 
 /* ラインタイプ　かつ --odd */
-.nwa .gray-tab-style-line.gray-tab-label-equal.--odd .tab-label-group .tab-label:nth-child(3n+1)::before {
+.nwa .gray-tab-style-line.gray-tab-label-equal:not([class*="is-style-grytab"]).--odd .tab-label-group .tab-label:nth-child(3n+1)::before,
+.nwa .is-style-grytab-line-equal-odd .tab-label-group .tab-label:nth-child(3n+1)::before {
   display: none;
 }
+
+/* オプション：均等配置 PC時のみセンター ver はnwaに配置されたら even均等配置にする　*/
+.nwa .gray-tab-label-equal:not([class*="is-style-grytab"]).--pc-center .tab-label-group,
+.nwa :where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group {
+  display: grid;
+  grid-template-rows: auto;
+  grid-template-columns: repeat(auto-fit, minmax(40%, 1fr));
+  row-gap: 4px;
+}
+
+.nwa .gray-tab-label-equal:not([class*="is-style-grytab"]).--pc-center .tab-label-group .tab-label,
+.nwa :where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group .tab-label {
+  /* flex: 0 0 25%; */
+  text-align: center;
+}
+
 
 /* サイドバーpadding */
 .skin-grayish .sidebar-menu-content .sidebar.nwa {
@@ -3043,7 +3111,7 @@ blockquote cite {
   padding: 1.2em 0;
 }
 
-.nwa .gray-tab-style-cir .tab-content-group,
+.nwa :is(.gray-tab-style-cir, .is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-content-group,
 .nwa .footer-widgets .tab-content-group,
 .nwa .footer-widgets-mobile .tab-content-group {
   padding: 1.2em 0.8em;
@@ -5547,7 +5615,9 @@ body:has(#spotlight.show) .header {
 
   /* tab box for front */
   /* even */
-  .gray-tab-label-equal .tab-label-group {
+  .gray-tab-label-equal:not([class*="is-style-grytab"]).tab-block .tab-label-group,
+  :where(.is-style-grytab-low-line-equal, .is-style-grytab-up-line-equal, .is-style-grytab-tablabel-equal, .is-style-grytab-line-equal, .is-style-grytab-cir-equal).tab-block .tab-label-group,
+  :where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc).tab-block .tab-label-group {
     display: grid;
     grid-template-rows: auto;
     grid-template-columns: repeat(auto-fit, minmax(40%, 1fr));
@@ -5555,24 +5625,29 @@ body:has(#spotlight.show) .header {
   }
 
   /* odd (Max 3想定) */
-  .gray-tab-label-equal.--odd .tab-label-group {
+  .gray-tab-label-equal.--odd:not([class*="is-style-grytab"]) .tab-label-group,
+  :where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd).tab-block .tab-label-group {
     display: grid;
     grid-template-rows: auto;
     grid-template-columns: repeat(auto-fit, minmax(30%, 1fr));
     row-gap: 4px;
   }
 
-  .gray-tab-label-equal .tab-label-group .tab-label {
+  .gray-tab-label-equal:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
+  :where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group .tab-label,
+  :where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label {
     font-size: clamp(0.75rem, 0.6397rem + 0.3676vw, 0.875rem);
   }
 
   /* ラインタイプ　かつ even */
-  .gray-tab-style-line.gray-tab-label-equal:not(.--odd) .tab-label-group .tab-label:nth-child(odd)::before {
+  .gray-tab-style-line.gray-tab-label-equal:not(.--odd):not([class*="is-style-grytab"]) .tab-label-group .tab-label:nth-child(odd)::before,
+  :where(.is-style-grytab-line-equal, .is-style-grytab-line-equal-pc) .tab-label-group .tab-label:nth-child(odd)::before {
     display: none;
   }
 
   /* ラインタイプ　かつ --odd */
-  .gray-tab-style-line.gray-tab-label-equal.--odd .tab-label-group .tab-label:nth-child(3n+1)::before {
+  .gray-tab-style-line.gray-tab-label-equal.--odd:not([class*="is-style-grytab"]) .tab-label-group .tab-label:nth-child(3n+1)::before,
+  .is-style-grytab-line-equal-odd .tab-label-group .tab-label:nth-child(3n+1)::before {
     display: none;
   }
 
@@ -5903,6 +5978,7 @@ body:has(#spotlight.show) .header {
     justify-self: center;
     border-left: 0px;
     padding-left: 0rem;
+    width: 100%;
   }
 
   :where(.main, .content-bottom, .content-top) .author-box .author-follows .sns-follow-buttons,

--- a/skins/skin-grayish-topfull/style.css
+++ b/skins/skin-grayish-topfull/style.css
@@ -1,5 +1,4 @@
 @charset "UTF-8";
-
 /*!
   Skin Name: grayish
   Description: グレイベースのシンプルデザイン フロントページにメインビジュアルを画面高さいっぱいに表示するスキンです
@@ -7,7 +6,7 @@
   Author: Na2factory
   Author URI: https://na2-factory.com/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-grayish-topfull.webp
-  Version: 1.1.5
+  Version: 2.0.0
   Priority: 7000001000
   License: GNU General Public License
   License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -178,9 +177,12 @@ html {
   scroll-padding-top: 100px;
 }
 
-.skin-grayish {
+.body {
   letter-spacing: .16rem;
   font-feature-settings: 'palt';
+}
+
+.skin-grayish {
   overflow-x: hidden;
 }
 
@@ -2361,6 +2363,11 @@ dialog[open] .searchMenuDialog_close.grayish-btn {
   position: relative;
 }
 
+.blank-box.bb-tab .bb-label {
+  display: flex;
+  align-items: center;
+}
+
 .skin-grayish .blank-box.bb-tab .bb-label {
   background-color: var(--LtBlue_S30);
   position: absolute;
@@ -2839,13 +2846,13 @@ blockquote cite {
   bottom: 0;
 }
 
-[class*="gray-tab-style"] .tab-content-group {
+/* [class*="gray-tab-style"] .tab-content-group {
   border: none;
 }
 
 [class*="gray-tab-style"] .tab-label-group .tab-label::after {
   display: none;
-}
+} */
 
 /* オプション：１カラム フロントページ向け */
 /* オプション：フォントサイズ 16px -> 10pxへレスポンシブ */
@@ -2855,33 +2862,43 @@ blockquote cite {
 
 
 /* オプション：均等配置 ver */
-.gray-tab-label-equal .tab-label-group {
+.gray-tab-label-equal:not([class*="is-style-grytab"]) .tab-label-group,
+:where(.is-style-grytab-low-line-equal, .is-style-grytab-up-line-equal, .is-style-grytab-tablabel-equal, .is-style-grytab-line-equal, .is-style-grytab-cir-equal) .tab-label-group,
+:where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group,
+:where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd) .tab-label-group {
   justify-content: space-between;
   flex-wrap: wrap;
   overflow-wrap: anywhere;
   white-space: normal;
 }
 
-.gray-tab-label-equal .tab-label-group .tab-label {
+.gray-tab-label-equal:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
+:where(.is-style-grytab-low-line-equal, .is-style-grytab-up-line-equal, .is-style-grytab-tablabel-equal, .is-style-grytab-line-equal, .is-style-grytab-cir-equal) .tab-label-group .tab-label,
+:where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label {
   flex: 1;
   text-align: center;
 }
 
 /* オプション：均等配置 PC時のみセンター ver */
-.gray-tab-label-equal.--pc-center .tab-label-group {
+.gray-tab-label-equal.--pc-center:not([class*="is-style-grytab"]) .tab-label-group,
+:where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group {
   justify-content: center;
 }
 
-.gray-tab-label-equal.--pc-center .tab-label-group .tab-label {
+.gray-tab-label-equal.--pc-center:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
+:where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group .tab-label {
   flex: 0 0 25%;
+  text-align: center;
 }
 
 /* スタイル１：線 upper-type */
-.gray-tab-style-up .tab-label-group .tab-label.is-active::after {
+.gray-tab-style-up:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active::after,
+:where(.is-style-grytab-up-line, .is-style-grytab-up-line-equal, .is-style-grytab-up-line-equal-pc, .is-style-grytab-up-line-equal-odd) .tab-label-group .tab-label.is-active::after {
   background-color: var(--skin-grayish-site-main-hover);
 }
 
-.gray-tab-style-up .tab-label-group .tab-label::after {
+.gray-tab-style-up:not([class*="is-style-grytab"]) .tab-label-group .tab-label::after,
+:where(.is-style-grytab-up-line, .is-style-grytab-up-line-equal, .is-style-grytab-up-line-equal-pc, .is-style-grytab-up-line-equal-odd) .tab-label-group .tab-label::after {
   display: block;
   content: "";
   background-color: transparent;
@@ -2899,24 +2916,27 @@ blockquote cite {
 /* .gray-tab-style .tab-content-group {
   background-color: var(--LtBlue_T90);
 } */
-
-.gray-tab-style .tab-label-group .tab-label {
+.gray-tab-style:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
+:where(.is-style-grytab-tablabel, .is-style-grytab-tablabel-equal, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-tablabel-equal-odd) .tab-label-group .tab-label {
   padding: 0.5em 1.5em;
   background-color: var(--white);
   transition: background-color .4s;
 
 }
 
-.gray-tab-style .tab-label-group .tab-label.is-active {
+.gray-tab-style:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active,
+:where(.is-style-grytab-tablabel, .is-style-grytab-tablabel-equal, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-tablabel-equal-odd) .tab-label-group .tab-label.is-active {
   background-color: var(--LtBlue_T70);
   color: var(--LtGray_S50);
 }
 
-.gray-tab-style .tab-label-group .tab-label.is-active::after {
+.gray-tab-style:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active::after,
+:where(.is-style-grytab-tablabel, .is-style-grytab-tablabel-equal, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-tablabel-equal-odd) .tab-label-group .tab-label.is-active::after {
   background-color: var(--LtBlue_T0);
 }
 
-.gray-tab-style .tab-label-group .tab-label::after {
+.gray-tab-style:not([class*="is-style-grytab"]) .tab-label-group .tab-label::after,
+:where(.is-style-grytab-tablabel, .is-style-grytab-tablabel-equal, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-tablabel-equal-odd) .tab-label-group .tab-label::after {
   display: block;
   content: "";
   background-color: transparent;
@@ -2930,17 +2950,20 @@ blockquote cite {
 }
 
 /* スタイル3：ライン */
-.gray-tab-style-line .tab-content-group {
+.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-content-group,
+:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-content-group {
   border-top: 1px solid var(--LtGray_T70);
   border-bottom: 1px solid var(--LtGray_T70);
   background-color: var(--white);
 }
 
-.gray-tab-style-line .tab-label-group {
+.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group,
+:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group {
   padding-bottom: 0.5em;
 }
 
-.gray-tab-style-line .tab-label-group .tab-label {
+.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
+:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label {
   padding: 0.5em 1.5em;
   background-color: var(--white);
   color: var(--LtGray_T30);
@@ -2948,11 +2971,13 @@ blockquote cite {
 
 }
 
-.gray-tab-style-line .tab-label-group .tab-label.is-active {
+.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active,
+:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label.is-active {
   color: var(--LtGray_S50);
 }
 
-.gray-tab-style-line .tab-label-group .tab-label::before {
+.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label::before,
+:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label::before {
   display: block;
   content: "";
   background-color: var(--LtGray_T70);
@@ -2966,21 +2991,32 @@ blockquote cite {
 }
 
 
-.gray-tab-style-line .tab-label-group .tab-label:first-child::before {
+.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label:first-child::before,
+:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label:first-child::before {
+  display: none;
+}
+
+.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active::after,
+:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label.is-active::after,
+.gray-tab-style-line:not([class*="is-style-grytab"]) .tab-label-group .tab-label::after,
+:where(.is-style-grytab-line, .is-style-grytab-line-equal, .is-style-grytab-line-equal-pc, .is-style-grytab-line-equal-odd) .tab-label-group .tab-label::after {
   display: none;
 }
 
 /* スタイル4：ラベルの端が円タイプ */
-.gray-tab-style-cir {
+.gray-tab-style-cir:not([class*="is-style-grytab"]),
+:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) {
   background-color: var(--Blk_Beige_T70);
 }
 
-.gray-tab-style-cir .tab-content-group {
+.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-content-group,
+:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-content-group {
   border-top: 1px solid var(--Blk_Beige_T0);
   background-color: var(--Blk_Beige_T70);
 }
 
-.gray-tab-style-cir .tab-label-group {
+.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-label-group,
+:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-label-group {
   background-color: var(--Blk_Beige_T70);
   row-gap: 8px;
   -moz-column-gap: 4px;
@@ -2988,7 +3024,8 @@ blockquote cite {
   padding: 2em 1em;
 }
 
-.gray-tab-style-cir .tab-label-group .tab-label {
+.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
+:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label {
   padding: 0.5em 1.5em;
   background-color: var(--white);
   border-radius: 30px 30px;
@@ -2997,15 +3034,24 @@ blockquote cite {
   transition: background-color .4s, color .4s;
 }
 
-.gray-tab-style-cir .tab-label-group .tab-label.is-active {
+.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active,
+:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label.is-active {
   background-color: var(--Blk_Beige_S50);
   color: var(--white);
+}
+
+.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-label-group .tab-label.is-active::after,
+:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label.is-active::after,
+.gray-tab-style-cir:not([class*="is-style-grytab"]) .tab-label-group .tab-label::after,
+:is(.is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label::after {
+  display: none;
 }
 
 
 /* tab box for .nwa */
 /* even */
-.nwa .gray-tab-label-equal .tab-label-group {
+.nwa .gray-tab-label-equal:not([class*="is-style-grytab"]) .tab-label-group,
+.nwa :where(.is-style-grytab-low-line-equal, .is-style-grytab-up-line-equal, .is-style-grytab-tablabel-equal, .is-style-grytab-line-equal, .is-style-grytab-cir-equal) .tab-label-group {
   display: grid;
   grid-template-rows: auto;
   grid-template-columns: repeat(auto-fit, minmax(40%, 1fr));
@@ -3013,26 +3059,48 @@ blockquote cite {
 }
 
 /* odd (Max 3想定) */
-.nwa .gray-tab-label-equal.--odd .tab-label-group {
+.nwa .gray-tab-label-equal.--odd:not([class*="is-style-grytab"]) .tab-label-group,
+.nwa :where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd) .tab-label-group {
   display: grid;
   grid-template-rows: auto;
   grid-template-columns: repeat(auto-fit, minmax(30%, 1fr));
   row-gap: 4px;
 }
 
-.nwa .gray-tab-label-equal .tab-label-group .tab-label {
+.nwa .gray-tab-label-equal:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
+.nwa :where(.is-style-grytab-low-line-equal, .is-style-grytab-up-line-equal, .is-style-grytab-tablabel-equal, .is-style-grytab-line-equal, .is-style-grytab-cir-equal) .tab-label-group .tab-label,
+.nwa :where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group .tab-label,
+.nwa :where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label {
   font-size: 12px;
 }
 
 /* ラインタイプ　かつ even */
-.nwa .gray-tab-style-line.gray-tab-label-equal:not(.--odd) .tab-label-group .tab-label:nth-child(odd)::before {
+.nwa .gray-tab-style-line.gray-tab-label-equal:not([class*="is-style-grytab"]):not(.--odd) .tab-label-group .tab-label:nth-child(odd)::before,
+.nwa :where(.is-style-grytab-line-equal, .is-style-grytab-line-equal-pc) .tab-label-group .tab-label:nth-child(odd)::before {
   display: none;
 }
 
 /* ラインタイプ　かつ --odd */
-.nwa .gray-tab-style-line.gray-tab-label-equal.--odd .tab-label-group .tab-label:nth-child(3n+1)::before {
+.nwa .gray-tab-style-line.gray-tab-label-equal:not([class*="is-style-grytab"]).--odd .tab-label-group .tab-label:nth-child(3n+1)::before,
+.nwa .is-style-grytab-line-equal-odd .tab-label-group .tab-label:nth-child(3n+1)::before {
   display: none;
 }
+
+/* オプション：均等配置 PC時のみセンター ver はnwaに配置されたら even均等配置にする　*/
+.nwa .gray-tab-label-equal:not([class*="is-style-grytab"]).--pc-center .tab-label-group,
+.nwa :where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group {
+  display: grid;
+  grid-template-rows: auto;
+  grid-template-columns: repeat(auto-fit, minmax(40%, 1fr));
+  row-gap: 4px;
+}
+
+.nwa .gray-tab-label-equal:not([class*="is-style-grytab"]).--pc-center .tab-label-group .tab-label,
+.nwa :where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group .tab-label {
+  /* flex: 0 0 25%; */
+  text-align: center;
+}
+
 
 /* サイドバーpadding */
 .skin-grayish .sidebar-menu-content .sidebar.nwa {
@@ -3043,7 +3111,7 @@ blockquote cite {
   padding: 1.2em 0;
 }
 
-.nwa .gray-tab-style-cir .tab-content-group,
+.nwa :is(.gray-tab-style-cir, .is-style-grytab-cir, .is-style-grytab-cir-equal, .is-style-grytab-cir-equal-pc, .is-style-grytab-cir-equal-odd) .tab-content-group,
 .nwa .footer-widgets .tab-content-group,
 .nwa .footer-widgets-mobile .tab-content-group {
   padding: 1.2em 0.8em;
@@ -5547,7 +5615,9 @@ body:has(#spotlight.show) .header {
 
   /* tab box for front */
   /* even */
-  .gray-tab-label-equal .tab-label-group {
+  .gray-tab-label-equal:not([class*="is-style-grytab"]).tab-block .tab-label-group,
+  :where(.is-style-grytab-low-line-equal, .is-style-grytab-up-line-equal, .is-style-grytab-tablabel-equal, .is-style-grytab-line-equal, .is-style-grytab-cir-equal).tab-block .tab-label-group,
+  :where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc).tab-block .tab-label-group {
     display: grid;
     grid-template-rows: auto;
     grid-template-columns: repeat(auto-fit, minmax(40%, 1fr));
@@ -5555,24 +5625,29 @@ body:has(#spotlight.show) .header {
   }
 
   /* odd (Max 3想定) */
-  .gray-tab-label-equal.--odd .tab-label-group {
+  .gray-tab-label-equal.--odd:not([class*="is-style-grytab"]) .tab-label-group,
+  :where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd).tab-block .tab-label-group {
     display: grid;
     grid-template-rows: auto;
     grid-template-columns: repeat(auto-fit, minmax(30%, 1fr));
     row-gap: 4px;
   }
 
-  .gray-tab-label-equal .tab-label-group .tab-label {
+  .gray-tab-label-equal:not([class*="is-style-grytab"]) .tab-label-group .tab-label,
+  :where(.is-style-grytab-low-line-equal-pc, .is-style-grytab-up-line-equal-pc, .is-style-grytab-tablabel-equal-pc, .is-style-grytab-line-equal-pc, .is-style-grytab-cir-equal-pc) .tab-label-group .tab-label,
+  :where(.is-style-grytab-low-line-equal-odd, .is-style-grytab-up-line-equal-odd, .is-style-grytab-tablabel-equal-odd, .is-style-grytab-line-equal-odd, .is-style-grytab-cir-equal-odd) .tab-label-group .tab-label {
     font-size: clamp(0.75rem, 0.6397rem + 0.3676vw, 0.875rem);
   }
 
   /* ラインタイプ　かつ even */
-  .gray-tab-style-line.gray-tab-label-equal:not(.--odd) .tab-label-group .tab-label:nth-child(odd)::before {
+  .gray-tab-style-line.gray-tab-label-equal:not(.--odd):not([class*="is-style-grytab"]) .tab-label-group .tab-label:nth-child(odd)::before,
+  :where(.is-style-grytab-line-equal, .is-style-grytab-line-equal-pc) .tab-label-group .tab-label:nth-child(odd)::before {
     display: none;
   }
 
   /* ラインタイプ　かつ --odd */
-  .gray-tab-style-line.gray-tab-label-equal.--odd .tab-label-group .tab-label:nth-child(3n+1)::before {
+  .gray-tab-style-line.gray-tab-label-equal.--odd:not([class*="is-style-grytab"]) .tab-label-group .tab-label:nth-child(3n+1)::before,
+  .is-style-grytab-line-equal-odd .tab-label-group .tab-label:nth-child(3n+1)::before {
     display: none;
   }
 


### PR DESCRIPTION
スキンのverを1.1.5から2.0.0に変更します。
以下のgrayishマニュアルに公開している変更内容になります。
https://cocoon-grayish.na2-factory.com/rel-infor-18/

①タブブロックのスタイル選択を簡単にできるように
②Googleフォントの読み込みの変更
③記事本文の文字間隔（letter-spacing）の表示をエディタと合わせる

どうぞよろしくお願いいたします。