### PR TITLE
grayishスキンのアップデート v2.0.1

### DIFF
--- a/skins/skin-grayish-topfull/functions.php
+++ b/skins/skin-grayish-topfull/functions.php
@@ -378,7 +378,11 @@ if (!function_exists('skin_grayish_titlefont_weight')) :
 	';
     $style_font_weight = '';
     if (get_theme_mod('title_font_weight_radio', 'font_weight_Thin') === 'font_weight_Thin') {
-      $style_font_weight = '200';
+      if (get_theme_mod('font_pat_control_radio', 'font_Montserrat') === 'font_Jost' || get_theme_mod('font_pat_control_radio', 'font_Montserrat') === 'font_Lato') {
+        $style_font_weight = '300';
+      } else {
+        $style_font_weight = '200';
+      }
     } elseif (get_theme_mod('title_font_weight_radio', 'font_weight_Thin') === 'font_weight_Normal') {
       $style_font_weight = '400';
     }

--- a/skins/skin-grayish-topfull/style.css
+++ b/skins/skin-grayish-topfull/style.css
@@ -6,7 +6,7 @@
   Author: Na2factory
   Author URI: https://na2-factory.com/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-grayish-topfull.webp
-  Version: 2.0.0
+  Version: 2.0.1
   Priority: 7000001000
   License: GNU General Public License
   License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
引き続き申し訳ありません。

Googleフォント JostとLatoについて、細いウェイトの選択がされたときに
300を設定するように修正させていただきたいと思います。

スキンのverを2.0.1にします。

どうぞよろしくお願いいたします。
