### PR TITLE
grayishスキンのアップデート v2.0.3

### DIFF
--- a/skins/skin-grayish-topfull/editor-style.css
+++ b/skins/skin-grayish-topfull/editor-style.css
@@ -42,12 +42,12 @@
 	padding: 0.2em 1.2em 0.2em 0.8em !important;
 }
 
-
-.editor-styles-wrapper .tab-caption-box-label {
+/* WP6.7以降で見出し色に影響あり */
+/* .editor-styles-wrapper .tab-caption-box-label {
 	--cocoon-custom-text-color: var(--white);
 	color: var(--cocoon-custom-text-color);
 	background-color: var(--cocoon-custom-border-color);
-}
+} */
 
 /* タイムラインBoxの中にアイコンリスト使用すると、アイコンが表示されないことの対応 */
 .editor-styles-wrapper .timeline-box li {

--- a/skins/skin-grayish-topfull/style.css
+++ b/skins/skin-grayish-topfull/style.css
@@ -6,7 +6,7 @@
   Author: Na2factory
   Author URI: https://na2-factory.com/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-grayish-topfull.webp
-  Version: 2.0.2
+  Version: 2.0.3
   Priority: 7000001000
   License: GNU General Public License
   License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
お世話になっております。
申し訳ありません。以下不具合修正になります。

【不具合内容】
WordPress6.7にアップデートすると、
エディターでタブ見出しボックスの見出し背景色がスキンカラーではなく、グレーになってしまう
表示側には影響なし。

<img width="903" alt="editor" src="https://github.com/user-attachments/assets/f8f38f00-3c10-4253-9970-474e02ff26ac">

↓表示側ではスキンカラーになる
<img width="903" alt="表示側" src="https://github.com/user-attachments/assets/22bbcbec-e13f-4fc6-853b-0d6543ad3b07">


editor-style.cssに書いていたタブ見出しボックスのスタイルを削除して対応。
※WordPress6.7以前のverへの影響について、6.5.3、6.6.2では修正前後で影響ないことを確認しております。
↓修正後は、エディター内でも見出し背景色がスキンカラーになります。
<img width="903" alt="修正後-editor" src="https://github.com/user-attachments/assets/5f934fc4-0b80-4fe9-a776-39fe52f1421d">

どうぞよろしくお願いいたします。
