### PR TITLE
[誤字・脱字報告]管理者設定の文言についての対応

### DIFF
--- a/languages/cocoon.pot
+++ b/languages/cocoon.pot
@@ -3752,7 +3752,7 @@ msgid "管理画面の機能設定です。"
 msgstr ""
 
 #: lib/page-settings/admin-forms.php:24
-msgid "管理者メニュー"
+msgid "管理メニュー"
 msgstr ""
 
 #: lib/page-settings/admin-forms.php:25
@@ -3760,7 +3760,7 @@ msgid "管理画面に素早く移動するためのメニューリンクです�
 msgstr ""
 
 #: lib/page-settings/admin-forms.php:31
-msgid "アドミンバーに独自管理メニューを表示"
+msgid "ツールバーに独自管理メニューを表示"
 msgstr ""
 
 #: lib/page-settings/admin-forms.php:32
@@ -3808,7 +3808,7 @@ msgid "投稿・固定ページ記事一覧テーブルのカラム操作。"
 msgstr ""
 
 #: lib/page-settings/admin-forms.php:99
-msgid "作成者を表示する"
+msgid "投稿者を表示する"
 msgstr ""
 
 #: lib/page-settings/admin-forms.php:102
@@ -3830,7 +3830,7 @@ msgid "日付を表示する"
 msgstr ""
 
 #: lib/page-settings/admin-forms.php:115
-msgid "投稿IDを表示する"
+msgid "IDを表示する"
 msgstr ""
 
 #: lib/page-settings/admin-forms.php:118

--- a/lib/page-settings/admin-forms.php
+++ b/lib/page-settings/admin-forms.php
@@ -21,14 +21,14 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
         <!-- 管理者向け設定  -->
         <tr>
           <th scope="row">
-            <?php generate_label_tag('', __( '管理者メニュー', THEME_NAME ) );
+            <?php generate_label_tag('', __( '管理メニュー', THEME_NAME ) );
             generate_preview_tooltip_tag('https://im-cocoon.net/wp-content/uploads/admin-menu.png', __( '管理画面に素早く移動するためのメニューリンクです。', THEME_NAME )); ?>
           </th>
           <td>
             <?php
 
             //アドミンバーに独自管理メニューを表示
-            generate_checkbox_tag(OP_ADMIN_TOOL_MENU_VISIBLE, is_admin_tool_menu_visible(), __( 'アドミンバーに独自管理メニューを表示', THEME_NAME ));
+            generate_checkbox_tag(OP_ADMIN_TOOL_MENU_VISIBLE, is_admin_tool_menu_visible(), __( 'ツールバーに独自管理メニューを表示', THEME_NAME ));
             generate_tips_tag(__( '管理者バーに手軽に設定画面にアクセスできるメニューを表示します。', THEME_NAME ));
             ?>
           </td>
@@ -74,11 +74,11 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
 
 <!-- 投稿一覧設定 -->
 <div id="admin-single-index" class="postbox">
-  <h2 class="hndle"><?php _e( '投稿一覧設定', THEME_NAME ) ?></h2>
+  <h2 class="hndle"><?php _e( '投稿一覧・固定ページ一覧設定', THEME_NAME ) ?></h2>
   <div class="inside">
 
     <p><?php
-      _e( '管理画面の投稿一覧ページの設定です。', THEME_NAME );
+      _e( '管理画面の投稿一覧・固定ページ一覧ページの設定です。', THEME_NAME );
       generate_help_page_tag('https://wp-cocoon.com/post-columns-switch/');
      ?></p>
 
@@ -96,7 +96,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
           <td>
             <?php
 
-            generate_checkbox_tag(OP_ADMIN_LIST_AUTHOR_VISIBLE , is_admin_list_author_visible(), __( '作成者を表示する', THEME_NAME ));
+            generate_checkbox_tag(OP_ADMIN_LIST_AUTHOR_VISIBLE , is_admin_list_author_visible(), __( '投稿者を表示する', THEME_NAME ));
             echo '<br>';
 
             generate_checkbox_tag(OP_ADMIN_LIST_CATEGORIES_VISIBLE , is_admin_list_categories_visible(), __( 'カテゴリーを表示する', THEME_NAME ));
@@ -112,7 +112,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
             generate_checkbox_tag(OP_ADMIN_LIST_DATE_VISIBLE , is_admin_list_date_visible(), __( '日付を表示する', THEME_NAME ));
             echo '<br>';
 
-            generate_checkbox_tag(OP_ADMIN_LIST_POST_ID_VISIBLE , is_admin_list_post_id_visible(), __( '投稿IDを表示する', THEME_NAME ));
+            generate_checkbox_tag(OP_ADMIN_LIST_POST_ID_VISIBLE , is_admin_list_post_id_visible(), __( 'IDを表示する', THEME_NAME ));
             echo '<br>';
 
             generate_checkbox_tag(OP_ADMIN_LIST_WORD_COUNT_VISIBLE , is_admin_list_word_count_visible(), __( '文字数を表示する', THEME_NAME ));

--- a/lib/page-settings/admin-forms.php
+++ b/lib/page-settings/admin-forms.php
@@ -292,7 +292,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
               generate_checkbox_tag(OP_ADMIN_SEOCHEKI_VISIBLE, is_admin_seocheki_visible(), __( 'SEOチェキを表示する', THEME_NAME ));
               generate_tips_tag(__( '<a href="http://seocheki.net/" target="_blank" rel="noopener">SEOチェキ! 無料で使えるSEOツール</a>リンクの表示。', THEME_NAME ));
 
-              generate_checkbox_tag(OP_ADMIN_TWEET_CHECK_VISIBLE, is_admin_tweet_check_visible(), __( 'ツイートチェックを表示する', THEME_NAME ));
+              generate_checkbox_tag(OP_ADMIN_TWEET_CHECK_VISIBLE, is_admin_tweet_check_visible(), __( 'ツイート検索を表示する', THEME_NAME ));
               generate_tips_tag(__( '投稿・固定ページに対するツイートチェックリンクの表示。', THEME_NAME ));
                ?>
             </div>

--- a/lib/page-settings/admin-forms.php
+++ b/lib/page-settings/admin-forms.php
@@ -293,7 +293,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
               generate_tips_tag(__( '<a href="http://seocheki.net/" target="_blank" rel="noopener">SEOチェキ! 無料で使えるSEOツール</a>リンクの表示。', THEME_NAME ));
 
               generate_checkbox_tag(OP_ADMIN_TWEET_CHECK_VISIBLE, is_admin_tweet_check_visible(), __( 'ツイート検索を表示する', THEME_NAME ));
-              generate_tips_tag(__( '投稿・固定ページ・インデックスページに対するツイートチェックリンクの表示。', THEME_NAME ));
+              generate_tips_tag(__( '投稿・固定ページ・インデックスページに対するツイート検索リンクの表示。', THEME_NAME ));
                ?>
             </div>
           </td>

--- a/lib/page-settings/admin-forms.php
+++ b/lib/page-settings/admin-forms.php
@@ -293,7 +293,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
               generate_tips_tag(__( '<a href="http://seocheki.net/" target="_blank" rel="noopener">SEOチェキ! 無料で使えるSEOツール</a>リンクの表示。', THEME_NAME ));
 
               generate_checkbox_tag(OP_ADMIN_TWEET_CHECK_VISIBLE, is_admin_tweet_check_visible(), __( 'ツイート検索を表示する', THEME_NAME ));
-              generate_tips_tag(__( '投稿・固定ページに対するツイートチェックリンクの表示。', THEME_NAME ));
+              generate_tips_tag(__( '投稿・固定ページ・インデックスページに対するツイートチェックリンクの表示。', THEME_NAME ));
                ?>
             </div>
           </td>

--- a/lib/page-settings/admin-forms.php
+++ b/lib/page-settings/admin-forms.php
@@ -306,7 +306,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
           </th>
           <td>
             <?php
-            generate_checkbox_tag(OP_ADMIN_PANEL_RESPONSIVE_TOOLS_AREA_VISIBLE, is_admin_panel_responsive_tools_area_visible(), __( 'レスポンシブチェックを表示する', THEME_NAME ));
+            generate_checkbox_tag(OP_ADMIN_PANEL_RESPONSIVE_TOOLS_AREA_VISIBLE, is_admin_panel_responsive_tools_area_visible(), __( 'レスポンシブチェックツールエリアを表示する', THEME_NAME ));
             generate_tips_tag(__( 'レスポンシブ表示状態を効率的にチェックできるツールエリアの表示を切り替えます。', THEME_NAME ));
             ?>
             <div class="indent">

--- a/lib/page-settings/admin-forms.php
+++ b/lib/page-settings/admin-forms.php
@@ -29,7 +29,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
 
             //アドミンバーに独自管理メニューを表示
             generate_checkbox_tag(OP_ADMIN_TOOL_MENU_VISIBLE, is_admin_tool_menu_visible(), __( 'ツールバーに独自管理メニューを表示', THEME_NAME ));
-            generate_tips_tag(__( '管理者バーに手軽に設定画面にアクセスできるメニューを表示します。', THEME_NAME ));
+            generate_tips_tag(__( 'ツールバーに手軽に設定画面にアクセスできるメニューを表示します。', THEME_NAME ));
             ?>
           </td>
         </tr>

--- a/tmp/admin-panel.php
+++ b/tmp/admin-panel.php
@@ -68,7 +68,7 @@ if (is_user_administrator()
         $encoded_url = get_encoded_url(get_requested_url());
       ?>
       <?php if (is_admin_pagespeed_insights_visible()): ?>
-        <a href="https://developers.google.com/speed/pagespeed/insights/?filter_third_party_resources=true&hl=<?php _e( 'ja', THEME_NAME ) ?>&url=<?php echo $encoded_url; ?> " target="_blank" rel="noopener noreferrer" class="pagespeed"><?php _e( 'ページスピード', THEME_NAME ) ?></a>
+        <a href="https://developers.google.com/speed/pagespeed/insights/?filter_third_party_resources=true&hl=<?php _e( 'ja', THEME_NAME ) ?>&url=<?php echo $encoded_url; ?> " target="_blank" rel="noopener noreferrer" class="pagespeed"><?php _e( 'PageSpeed Insights', THEME_NAME ) ?></a>
       <?php endif ?>
       <?php if (is_admin_gtmetrix_visible()): ?>
         <a href="https://gtmetrix.com/?url=<?php echo $encoded_url; ?> " target="_blank" rel="noopener noreferrer" class="gtmetrix"><?php _e( 'GTmetrix', THEME_NAME ) ?></a>


### PR DESCRIPTION
# 該当のフォーラム

https://wp-cocoon.com/community/typos/%e7%ae%a1%e7%90%86%e8%80%85%e8%a8%ad%e5%ae%9a%e3%81%ae%e6%96%87%e8%a8%80%e3%81%ab%e3%81%a4%e3%81%84%e3%81%a6/

# 作業内容（2024.12.05）

以下の対応を致しました。問題なさそうであればマージいただける認識です。
Crowdinのやり方が現時点でわからず、potファイルに関しては取り急ぎ修正だけおこないました。

- 管理画面の文言修正
- potファイルの修正

# 実装イメージ

■修正前

![スクリーンショット (220)](https://github.com/user-attachments/assets/ce11c482-7f93-4002-90de-3e1294825daf)

■修正後

![スクリーンショット (219)](https://github.com/user-attachments/assets/f326695e-561d-402c-bc91-d77fd6b5da2b)