### PR TITLE
[スキンの不具合]エントリーカードのPV数が表示されない(不具合報告)の対応

### DIFF
--- a/tmp/admin-panel.php
+++ b/tmp/admin-panel.php
@@ -17,7 +17,7 @@ if (is_user_administrator()
 <div id="admin-panel" class="admin-panel<?php echo get_additional_admin_panel_area_classes(); ?>">
 
   <?php //PVエリアの表示
-  if (is_singular()) {
+  if (is_singular() && is_admin_panel_pv_area_visible()) {
     cocoon_template_part('tmp/admin-pv');
   }
    ?>

--- a/tmp/admin-pv.php
+++ b/tmp/admin-pv.php
@@ -8,7 +8,7 @@
 if ( !defined( 'ABSPATH' ) ) exit;
 
 //PVエリアの表示
-if (is_admin_panel_pv_area_visible()): ?>
+?>
   <div class="admin-pv">
     <span class="admin-pv-by">
       <?php if (get_admin_panel_pv_type() == THEME_NAME): ?>
@@ -43,4 +43,3 @@ if (is_admin_panel_pv_area_visible()): ?>
       echo '<span class="jetpack-page"><a href="'.admin_url().'admin.php?page=stats&view=post&post='.get_the_ID().'"title="'.__( 'Jetpackの統計', THEME_NAME ).'" target="_blank" rel="noopener noreferrer"><span class="fa fa-line-chart" aria-hidden="true"></span></a></span>';
     } ?>
   </div>
-<?php endif ?>


### PR DESCRIPTION
# 対象のフォーラム内容

https://wp-cocoon.com/community/skin-bugs/%e3%82%a8%e3%83%b3%e3%83%88%e3%83%aa%e3%83%bc%e3%82%ab%e3%83%bc%e3%83%89%e3%81%aepv%e6%95%b0%e3%81%8c%e8%a1%a8%e7%a4%ba%e3%81%95%e3%82%8c%e3%81%aa%e3%81%84/

# 不具合内容

[こちら](https://github.com/xserver-inc/cocoon/blob/4e8193c99cbc9bac774ff7bc55c8974ec4c34ada/tmp/admin-pv.php#L11)の対応後、[Cocoon設定]→[管理者画面]→インデックス設定「インデックスにPV数を表示する」をオンにしてもエントリーカードのPV数が表示されない。
「PVの表示」をあわせてチェックしなければ表示されないようになっていたため、こちらを修正。

それぞれ別々で表示の有無を設定できる必要があるため、
①「インデックスにPV数を表示する」をチェック→各インデックスページにてPVを表示
②「PVエリアを表示する」にチェック→管理者パネルにPVを表示
できるように修正いたしました。

# 対応内容

- tmp/admin-pv.phpのis_admin_panel_pv_area_visible()関数の判定を削除
- tmp/admin-panel.phpのPVエリア表示の条件分岐にis_admin_panel_pv_area_visible()を追加

# 実装イメージ

■下図の「インデックスにPV数を表示する」をチェックを入れることで、各インデックスページにてPVを表示。

![スクリーンショット (243)](https://github.com/user-attachments/assets/c3025484-640e-465c-bf50-9bf9d6fd40d1)

![スクリーンショット (246) (1)](https://github.com/user-attachments/assets/52445d6b-9e13-422a-a43d-7a2cfe94255d)

■下図の「PVエリアを表示する」にチェックを入れることで、管理者パネルにPVを表示。

![スクリーンショット (244)](https://github.com/user-attachments/assets/3461c7e8-fdde-42f0-8043-38ed6df9a8ee)

![スクリーンショット (245)](https://github.com/user-attachments/assets/68525384-a62c-4d6d-b15f-a104ee65854e)