### PR TITLE
[誤字・脱字報告]新着記事ブロックなどの文言についての対応

### DIFF
--- a/blocks/src/block/new-list/edit.js
+++ b/blocks/src/block/new-list/edit.js
@@ -215,7 +215,7 @@ export default function edit( props ) {
             onChange={ ( isChecked ) => setAttributes( { arrow: isChecked } ) }
           />
           <ToggleControl
-            label={ __( '説明文の表示', THEME_NAME ) }
+            label={ __( '説明文を表示する', THEME_NAME ) }
             checked={ snippet }
             onChange={ ( isChecked ) =>
               setAttributes( { snippet: isChecked } )

--- a/lib/page-speed-up/_top-page.php
+++ b/lib/page-speed-up/_top-page.php
@@ -36,7 +36,7 @@ if( isset($_POST[HIDDEN_FIELD_NAME]) &&
 ///////////////////////////////////////
 ?>
 <div class="wrap admin-settings">
-  <h1><?php _e( 'サイト高速化', THEME_NAME ) ?></h1>
+  <h1><?php _e( '高速化', THEME_NAME ) ?></h1>
   <form name="form1" method="post" action="" class="admin-settings">
     <p><?php _e( 'サイト表示スピードの高速化設定を行います。', THEME_NAME );
     echo get_help_page_tag('https://wp-cocoon.com/site-speed-up/'); ?></p>

--- a/lib/page-speed-up/speed-up-forms.php
+++ b/lib/page-speed-up/speed-up-forms.php
@@ -22,11 +22,11 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
         <!-- ブラウザキャッシュ  -->
         <tr>
           <th scope="row">
-            <?php generate_label_tag(OP_BROWSER_CACHE_ENABLE, __( 'ブラウザキャッシュ', THEME_NAME ) ); ?>
+            <?php generate_label_tag(OP_BROWSER_CACHE_ENABLE, __( 'キャッシュの有効化', THEME_NAME ) ); ?>
           </th>
           <td>
             <?php
-            generate_checkbox_tag(OP_BROWSER_CACHE_ENABLE , is_browser_cache_enable(), __( 'ブラウザキャッシュを有効にする', THEME_NAME ));
+            generate_checkbox_tag(OP_BROWSER_CACHE_ENABLE , is_browser_cache_enable(), __( 'キャッシュを有効にする', THEME_NAME ));
             generate_tips_tag(__( 'ブラウザキャッシュを有効化することで、訪問者が2回目以降リソースファイルをサーバーから読み込む時間を軽減できます。', THEME_NAME ));
             ?>
           </td>


### PR DESCRIPTION
# 対象のフォーラム内容

https://wp-cocoon.com/community/typos/%e6%96%b0%e7%9d%80%e8%a8%98%e4%ba%8b%e3%83%96%e3%83%ad%e3%83%83%e3%82%af%e3%81%aa%e3%81%a9%e3%81%ae%e6%96%87%e8%a8%80%e3%81%ab%e3%81%a4%e3%81%84%e3%81%a6/#post-82930

# 対応内容

- blocks/src/block/new-list/edit.jsの「説明文の表示」を「説明文を表示する」に文言変更
- lib/page-speed-up/_top-page.phpの「サイト高速化」を「高速化」に文言変更
- lib/page-speed-up/speed-up-forms.phpの「ブラウザキャッシュ」を「キャッシュの有効化」へ、「ブラウザキャッシュを有効にする」を「キャッシュを有効にする」に文言変更

■新着記事ブロック（修正後）

下図のように、画面右下の「説明文の表示」を「説明文を表示する」へ変更しました。

![cropped-image (31)](https://github.com/user-attachments/assets/5b4c4a94-8738-476b-92fb-b8f26928067c)

■Cocoon設定の高速化設定ページ（修正後）

下図のように、画面上ページ見出し「高速化」の1点と、「ブラウザキャッシュ」セクションの2点の合計3点を変更しました。

![cropped-image (30)](https://github.com/user-attachments/assets/84f1ca76-d33c-412e-8330-2be9f0228a72)