### PR TITLE
grayishスキンのアップデート v2.0.5

### DIFF
--- a/skins/skin-grayish-topfull/style.css
+++ b/skins/skin-grayish-topfull/style.css
@@ -6,7 +6,7 @@
   Author: Na2factory
   Author URI: https://na2-factory.com/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-grayish-topfull.webp
-  Version: 2.0.4
+  Version: 2.0.5
   Priority: 7000001000
   License: GNU General Public License
   License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -167,10 +167,6 @@
 }
 
 /****************************** Common ******************************/
-/* v1.1.3 */
-*, :after, :before {
-  min-inline-size: 0
-}
 
 html {
   scroll-behavior: smooth;
@@ -183,7 +179,7 @@ html {
 }
 
 .skin-grayish {
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 .skin-grayish .container {
@@ -3592,7 +3588,7 @@ blockquote cite {
 /****************************** Footer  ******************************/
 .skin-grayish .footer {
   background-color: var(--LtGray_T70);
-  overflow-x: hidden;
+  overflow-x: clip;
   margin-top: 0;
 }
 


### PR DESCRIPTION
お世話になっております。

スキンのCSSを修正させてください。

修正1
v1.1.3で追加した
https://github.com/xserver-inc/cocoon/blob/fc4408435e0bffa9ac94aa09d2cc392e7f504e15/skins/skin-grayish-topfull/style.css#L171
について、もしもアフィリエイトのかんたんリンクの表示くずれの原因となっており
他にも同様な不具合が発生する可能性があるため、削除します。

修正2
スキンリリース時から、body等に横スクロール防止で入れている
overflow-x: hidden;をclip;に変更します。
clipはiOS16以上で有効ですが、1年経過し現在iOS18台が最新となり
そろそろ変更しても影響がないと判断しました。

大変お手数ですが、どうぞよろしくお願いいたします。
