### PR TITLE
[誤字・脱字報告] [C]ナビガードの場合、メニューの「リンクを新しいタブで開く」が反映されない、の修正対応

### DIFF
--- a/lib/html-forms.php
+++ b/lib/html-forms.php
@@ -1588,11 +1588,14 @@ function get_widget_entry_card_link_tag($atts){
     'object' => 'post',
     'object_id' => null,
     'horizontal' => 0,
+    'target' => null,
   ), $atts));
+
   $class_text = null;
   if (isset($classes[0]) && !empty($classes[0])) {
     $class_text = ' '.implode(' ', $classes);
   }
+
   //リボンタグの取得
   $ribbon_tag = get_navi_card_ribbon_tag($ribbon_no);
   $swiper_slide = null;
@@ -1607,8 +1610,11 @@ function get_widget_entry_card_link_tag($atts){
     $div_class = 'class="'.implode(' ', get_post_class( array('post-'.get_the_ID(), $prefix.'-entry-card', 'widget-entry-card', 'e-card', 'cf') )).'"';
   }
 
+  // target 属性の設定
+  $target_attr = $target ? ' target="' . esc_attr($target) . '"' : '';
+
   ob_start(); ?>
-  <a href="<?php echo esc_url($url); ?>" class="<?php echo $prefix; ?>-entry-card-link widget-entry-card-link a-wrap<?php echo $class_text; ?><?php echo $swiper_slide; ?>" title="<?php echo esc_attr($title); ?>">
+  <a href="<?php echo esc_url($url); ?>" class="<?php echo $prefix; ?>-entry-card-link widget-entry-card-link a-wrap<?php echo $class_text; ?><?php echo $swiper_slide; ?>" title="<?php echo esc_attr($title); ?>"<?php echo $target_attr; ?>>
     <div <?php echo $div_class; ?>>
       <?php echo $ribbon_tag; ?>
       <figure class="<?php echo $prefix; ?>-entry-card-thumb widget-entry-card-thumb card-thumb">

--- a/lib/shortcodes.php
+++ b/lib/shortcodes.php
@@ -640,6 +640,9 @@ function get_navi_card_list_tag($atts){
     $object_id = $menu->object_id;
     $ribbon_no = isset($menu->classes[0]) ? $menu->classes[0] : null;
 
+    // target 属性を取得
+    $target = isset($menu->target) && $menu->target === '_blank' ? '_blank' : '';
+
     //アイテムタグの取得
     $atts = array(
       'prefix' => WIDGET_NAVI_ENTRY_CARD_PREFIX,
@@ -653,6 +656,7 @@ function get_navi_card_list_tag($atts){
       'object' => $object,
       'object_id' => $object_id,
       'horizontal' => $horizontal,
+      'target' => $target,
     );
     $tag .= get_widget_entry_card_link_tag($atts);
 


### PR DESCRIPTION
# 対象のフォーラム内容

https://wp-cocoon.com/community/bugs/c%e3%83%8a%e3%83%93%e3%82%ac%e3%83%bc%e3%83%89%e3%81%ae%e5%a0%b4%e5%90%88%e3%80%81%e3%83%a1%e3%83%8b%e3%83%a5%e3%83%bc%e3%81%ae%e3%80%8c%e3%83%aa%e3%83%b3%e3%82%af%e3%82%92%e6%96%b0%e3%81%97/#post-83441

# 不具合内容

「メニュー機能」で作成したメニュー項目に「リンクを新しいタブで開く（target="_blank"）」を有効にしたうえで、「ウィジェット機能」の「[C] ナビカード」でその作成したメニューを設定して表示させても「リンクを新しいタブで開く」が機能していない。
他ウィジェットの「[C] ボックスメニュー」では機能している。

# イメージ

①メニュー機能で作成した一部のメニュー項目に「リンクを新しいタブで開く」を有効にしたうえで作成

<img width="448" alt="スクリーンショット 2025-01-17 161207" src="https://github.com/user-attachments/assets/5657c6ac-b600-4b3b-8861-3b06fbf15350" />

②ウィジェット機能の「[C] ナビカード」で「メニュー機能」で作成したメニューを設定

<img width="437" alt="スクリーンショット 2025-01-17 161340" src="https://github.com/user-attachments/assets/2ed3befc-9988-4e50-a2b4-2cffddc2aadb" />

③ここで、「[C] ナビカード」にて「リンクを新しいタブで開く」を有効にした項目をクリックしても新しいタブで開かなかったが、今回修正して機能するようにいたしました。

<img width="341" alt="スクリーンショット 2025-01-17 161412" src="https://github.com/user-attachments/assets/d862710b-5a00-4ded-8068-790625111acc" />


# 対応内容

■ ナビカードリストでリンクの「新しいタブで開く」設定が反映されるよう修正
対象ファイル：lib\shortcodes.php

- get_navi_card_list_tag()関数内のforeach文内にtarget 属性を取得するコードを追加
- get_widget_entry_card_link_tag()関数へ配列のtargetパラメータ追加

■ ウィジェットエントリーカードリンクにtarget 属性の対応を追加
対象ファイル：lib\html-forms.php

- ショートコードで渡されるtarget属性を取得可能に修正
- 「リンクを新しいタブで開く」が有効の場合、aタグに適切に反映されるよう修正
- 「リンクを新しいタブで開く」が有効でない場合、taget="_blank"を反映しないように修正