### PR TITLE
grayishスキンのアップデート v2.0.6

### DIFF
--- a/skins/skin-grayish-topfull/option.csv
+++ b/skins/skin-grayish-topfull/option.csv
@@ -22,6 +22,7 @@ sidebar_position,sidebar_right
 ,,-------ヘッダー設定
 header_layout_type,center_logo_slim_top_menu
 header_fixed,0
+the_fixed_site_logo_url,
 ,,tagline_position,header_bottom
 header_area_height,
 mobile_header_area_height,

--- a/skins/skin-grayish-topfull/style.css
+++ b/skins/skin-grayish-topfull/style.css
@@ -6,7 +6,7 @@
   Author: Na2factory
   Author URI: https://na2-factory.com/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-grayish-topfull.webp
-  Version: 2.0.5
+  Version: 2.0.6
   Priority: 7000001000
   License: GNU General Public License
   License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -4790,6 +4790,12 @@ blockquote cite {
   padding-top: 4.5rem;
 }
 
+/* v2.0.6 コンテンツ下部のテキストor広告ウィジェット不具合修正 */
+/* テキストor広告（モバイル用）を非表示に */
+.skin-grayish .content-bottom .widget-content-bottom.widget_mobile_text,
+.skin-grayish .content-bottom .widget-content-bottom.widget_mobile_ad {
+  display: none;
+}
 
 /*============== Widget Footer : LargeSize ==============*/
 
@@ -5998,6 +6004,21 @@ body:has(#spotlight.show) .header {
     display: block;
     width: 100%;
   }
+
+  /* v2.0.6 コンテンツ下部のテキスト・広告ウィジェット不具合修正 */
+  /* テキスト（PC用）,テキスト（モバイル用） */
+  /* テキストor広告（モバイル用）を表示に */
+  .skin-grayish .content-bottom .widget-content-bottom.widget_mobile_text,
+  .skin-grayish .content-bottom .widget-content-bottom.widget_mobile_ad {
+    display: flex;
+  }
+
+  /* テキストor広告（PC用）を非表示に */
+  .skin-grayish .content-bottom .widget-content-bottom.widget_pc_text,
+  .skin-grayish .content-bottom .widget-content-bottom.widget_pc_ad {
+    display: none;
+  }
+
 
   /* 投稿下関連記事 */
   .skin-grayish .under-entry-content .related-list .related-entry-card-wrap {


### PR DESCRIPTION
お世話になっております。
①grayishの不具合修正
**コンテンツ下部ウィジェットエリア**について、以下不具合がありましたので修正させていただきます。

テキスト（PC用）、広告（PC用）
テキスト（モバイル用）、広告（モバイル用）
が画面幅834pxを境に表示ONOFFできるはずが、画面幅に関係なく常に表示されてしまう。

【修正後】
テキスト（PC用）、広告（PC用）：画面幅834pxより大きい場合に表示
テキスト（モバイル用）、広告（モバイル用）：面幅834px以下で表示

②スキン制御の追加
Cocoon2.8.4.6で追加された
https://github.com/xserver-inc/cocoon/commit/9c1240bdbec802f6861984cb29280ddce0167703
について、grayishは「ヘッダー固定時」が使用できないことと、「モバイル」に関しては
テーマカスタマイザーで同じ機能をすでに実装しており、ユーザーに混乱を招く可能性があるため、
スキン制御で使用不可とさせていただきたいと思います。
折角の機能追加ですが申し訳ありません。

大変お手数ですがご確認よろしくお願いいたします。
