### PR TITLE
【不具合報告】フロントページが「タブ一覧」「カテゴリーごと」のとき、除外カテゴリーの投稿が除外されない不具合の修正対応

### DIFF
--- a/lib/html-forms.php
+++ b/lib/html-forms.php
@@ -1160,7 +1160,7 @@ endif;
 
 //汎用エントリーウィジェットのタグ生成
 if ( !function_exists( 'generate_widget_entries_tag' ) ):
-function generate_widget_entries_tag($atts){
+function generate_widget_entries_tag($atts, $loop_index = 0){
   extract(shortcode_atts(array(
     'entry_count' => 5,
     'cat_ids' => array(),
@@ -1343,6 +1343,11 @@ function generate_widget_entries_tag($atts){
     'horizontal' => $horizontal,
   );
   $cards_classes = get_additional_widget_entry_cards_classes($atts);
+
+  // カウントを一意なキーで設定
+  $unique_count_key = 'count_' . $loop_index;
+  // カウントの初期値
+  $count = 0;
   ?>
   <div class="<?php echo $prefix; ?>-entry-cards widget-entry-cards no-icon cf<?php echo $cards_classes; ?>">
   <?php if ( $horizontal ) : ?>
@@ -1367,10 +1372,14 @@ function generate_widget_entries_tag($atts){
       );
     }
 
-    echo get_widget_entry_card_link_tag($atts); ?>
+    echo get_widget_entry_card_link_tag($atts);
+
+    set_query_var($unique_count_key, $count++); // 一意なキーでカウントを設定
+    ?>
   <?php endwhile;
   else :
     echo '<p>'.__( '記事は見つかりませんでした。', THEME_NAME ).'</p>';//見つからない時のメッセージ
+    set_query_var($unique_count_key, 0); // 記事がない場合は 0 を設定
   endif; ?>
   <?php wp_reset_postdata(); ?>
   <?php //wp_reset_query(); ?>

--- a/lib/page-settings/index-funcs.php
+++ b/lib/page-settings/index-funcs.php
@@ -364,6 +364,8 @@ function get_category_index_list_entry_card_tag($categories, $count){
     $count = 0;
   } else { // ここから記事が見つからなかった場合の処理
     cocoon_template_part('tmp/list-not-found-posts');
+    // 記事が見つからなかった場合はカウントを0にする
+    set_query_var('count', 0);
   }
   wp_reset_postdata();
   return ob_get_clean();

--- a/lib/page-settings/index-funcs.php
+++ b/lib/page-settings/index-funcs.php
@@ -342,7 +342,7 @@ function get_category_index_list_entry_card_tag($categories, $count){
 
   //カテゴリーの除外
   $exclude_category_ids = get_archive_exclude_category_ids();
-  if (!$categories && $exclude_category_ids && is_array($exclude_category_ids)) {
+  if ($exclude_category_ids && is_array($exclude_category_ids)) {
     $args += array(
       'category__not_in' => $exclude_category_ids,
     );

--- a/tmp/list-category-columns.php
+++ b/tmp/list-category-columns.php
@@ -76,14 +76,25 @@ $count = get_index_category_entry_card_count();
         <div class="list <?php echo $class; ?>">
           <?php
           //新着記事リストの作成
-          generate_widget_entries_tag($atts);
+          generate_widget_entries_tag($atts, $i);
           ?>
         </div><!-- .list -->
-        <?php if($cat = get_category($cat_id)): ?>
-          <div class="list-more-button-wrap">
+
+
+        <?php if ($cat = get_category($cat_id)): ?>
+        <?php
+        // 一意なカウントを取得
+        $unique_count_key = 'count_' . $i;
+        $current_count = get_query_var($unique_count_key);
+
+          // カウントが 0 より大きい場合のみ表示
+          if ($current_count > 0): ?>
+            <div class="list-more-button-wrap">
               <a href="<?php echo get_category_link($cat_id); ?>" class="list-more-button"><?php echo apply_filters('more_button_caption', __( 'もっと見る', THEME_NAME )); ?></a>
-          </div>
+            </div>
+          <?php endif; ?>
         <?php endif; ?>
+
       </div><!-- .list-column -->
       <?php endif; ?>
 

--- a/tmp/list-category.php
+++ b/tmp/list-category.php
@@ -42,11 +42,19 @@ $count = get_index_category_entry_card_count();
         <div class="<?php echo get_index_list_classes(); ?>">
           <?php echo get_category_index_list_entry_card_tag($cat_id, $count); ?>
         </div><!-- .list -->
-        <?php if($cat = get_category($cat_id)): ?>
-          <div class="list-more-button-wrap">
-              <a href="<?php echo get_category_link($cat_id); ?>" class="list-more-button"><?php echo apply_filters('more_button_caption', __( 'もっと見る', THEME_NAME )); ?></a>
-          </div>
-        <?php endif; ?>
+        <?php
+        // カテゴリ情報を取得
+        if ($cat = get_category($cat_id)) {
+            // count が 0 でない場合のみ「もっと見る」ボタンを表示
+            if (get_query_var('count') > 0): ?>
+                <div class="list-more-button-wrap">
+                    <a href="<?php echo get_category_link($cat_id); ?>" class="list-more-button">
+                        <?php echo apply_filters('more_button_caption', __('もっと見る', THEME_NAME)); ?>
+                    </a>
+                </div>
+            <?php endif;
+        }
+        ?>
       </div><!-- .list-category- -->
       <?php endif; ?>
     <?php endfor; ?>

--- a/tmp/list-new-entries.php
+++ b/tmp/list-new-entries.php
@@ -19,7 +19,13 @@ $count = get_index_new_entry_card_count();
   <div class="<?php echo get_index_list_classes(); ?>">
     <?php echo get_category_index_list_entry_card_tag(null, $count); ?>
   </div><!-- .list -->
+  <?php
+  // count が 0 でない場合のみ「もっと見る」ボタンを表示
+  if (get_query_var('count') > 0): ?>
   <div class="list-more-button-wrap">
       <a href="<?php echo trailingslashit(get_bloginfo('url')) ?>?cat=0" class="list-more-button"><?php echo apply_filters('more_button_caption', __( 'もっと見る', THEME_NAME )); ?></a>
   </div>
+  <?php
+  endif;
+  ?>
 </div><!-- .list-new-entries -->

--- a/tmp/list-tab-index.php
+++ b/tmp/list-tab-index.php
@@ -59,6 +59,8 @@ $cat_count = apply_filters('cocoon_index_max_category_tab_count', 3);
                 'order' => 'DESC',
                 //カテゴリーをIDで指定
                 'category' => $cat_id,
+                //除外カテゴリーがある場合は除外
+                'category__not_in' => get_archive_exclude_category_ids(),
                 //アーカイブに表示しないページのID
                 'post__not_in' =>  get_archive_exclude_post_ids(),
             );
@@ -84,6 +86,9 @@ $cat_count = apply_filters('cocoon_index_max_category_tab_count', 3);
                 <a href="<?php echo get_category_link($cat_id); ?>" class="list-more-button"><?php echo apply_filters('more_button_caption', __( 'もっと見る', THEME_NAME )); ?></a>
             </div>
         <?php endif; ?>
+        <?php else: ?>
+            <h2>NOT FOUND</h2>
+            <p>投稿が見つかりませんでした。</p>
         <?php endif; ?>
     </div>
     <?php endif; ?>


### PR DESCRIPTION
# 対象のフォーラム内容

フォーラムタイトル：フロントページが「タブ一覧」「カテゴリーごと」のとき、除外カテゴリーの投稿が除外されない
https://wp-cocoon.com/community/bugs/%e3%83%95%e3%83%ad%e3%83%b3%e3%83%88%e3%83%9a%e3%83%bc%e3%82%b8%e3%81%8c%e3%80%8c%e3%82%bf%e3%83%96%e4%b8%80%e8%a6%a7%e3%80%8d%e3%80%8c%e3%82%ab%e3%83%86%e3%82%b4%e3%83%aa%e3%83%bc%e3%81%94%e3%81%a8/

# 本PRの目的

Cocoon 設定の「インデックス」の「フロントページタイプ」にて、「タブ一覧」もしくは「カテゴリーごと」を設定したとき、「除外カテゴリー」で設定したカテゴリーを紐づけた記事が表示されてしまうため、除外したい

「フロントページタイプ」の「一覧（デフォルト）」「カテゴリーごと（2カラム）」「カテゴリーごと（3カラム）」を設定したときは「除外カテゴリー」で設定したカテゴリーを紐づけた記事がちゃんと除外されるようになっているため、この仕様に「タブ一覧」「カテゴリーごと」も合わせたい

# 実装内容

■「タブ一覧」での修正で対応したこと

- tmp\list-tab-index.phpの44行目付近の「`for ($i=0; $i < count($cat_ids) && $i < $cat_count; $i++):`」内のクエリパラメーターにて、「`'category__not_in' => get_archive_exclude_category_ids(),`」を追加
- 「`<?php else: ?><h2>NOT FOUND</h2><p>投稿が見つかりませんでした。</p>`」を追加

https://github.com/xserver-inc/cocoon/pull/268/files#diff-dbe3ff3aadbc8ea8b3e6f351f67f626c86bfbe516fa5a3da34e89178da18d28d

■「カテゴリーごと」での修正で対応したこと

- lib\page-settings\index-funcs.phpのget_category_index_list_entry_card_tag()関数の「//カテゴリーの除外」のif文の「`!$categories &&`」を削除
（chu-yaさんのコードを参考にさせていただきました、ご提供いただきありがとうございました）

https://github.com/xserver-inc/cocoon/pull/268/files#diff-10d8681b8d271b558543427e446e8c4dd587a48b5e5121c9f150146bdf9e9a32

# 実装イメージ

## 修正前

まず修正前の状況をお伝えすると、下図のように、特定の記事ページに例えば「コーヒー」「日記」カテゴリーを設定し...

<img width="613" alt="スクリーンショット 2025-04-07 143504" src="https://github.com/user-attachments/assets/2e90bdfe-305f-42e7-981c-bd66070e3fbb" />

下図のように、Cocoon設定「インデックス」の「フロントページタイプ」にて「タブ一覧」を設定しつつ...

<img width="323" alt="スクリーンショット 2025-04-07 143135" src="https://github.com/user-attachments/assets/3afec2d2-30aa-44f4-a177-5bf5c9e486a1" />

「除外カテゴリー」にて「日記」カテゴリーを設定した場合...

<img width="362" alt="スクリーンショット 2025-04-07 143255" src="https://github.com/user-attachments/assets/f8894016-7971-40c9-be82-f3f7b089a1cb" />

下図のように、除外設定したはずの「日記」カテゴリーに紐づいている記事ページが表示されてしまっている。

<img width="484" alt="スクリーンショット 2025-04-07 143644" src="https://github.com/user-attachments/assets/e374f414-e4fe-48a8-bba4-ca9b0f5ce608" />

またあわせて、下図のように「フロントページタイプ」にて「カテゴリーごと」を設定した場合も...

<img width="347" alt="スクリーンショット 2025-04-07 143145" src="https://github.com/user-attachments/assets/bda460f1-096f-4363-ba18-178342da6329" />

下図のように、除外設定したはずの「日記」カテゴリーに紐づいている記事ページが表示されてしまっている。

<img width="485" alt="スクリーンショット 2025-04-07 143702" src="https://github.com/user-attachments/assets/4253d0c6-9f99-4767-a8d5-e0e97eeaa020" />

他「フロントページタイプ」の「一覧（デフォルト）」「カテゴリーごと（2カラム）」「カテゴリーごと（3カラム）」を設定したときは「除外カテゴリー」で設定したカテゴリーを紐づけた記事がちゃんと除外されるようになっている。

## 修正後

本PRでは上記修正前の状態を修正し、特定の記事ページに例えば「コーヒー」「日記」カテゴリーを設定し、「除外カテゴリー」にて「日記」カテゴリーを設定したなら、その「日記」カテゴリーに紐づいた記事ページは「タブ一覧」「カテゴリーごと」でも一覧から除外されるようにいたしました。

■「タブ一覧」設定時の修正後

<img width="482" alt="スクリーンショット 2025-04-07 143114" src="https://github.com/user-attachments/assets/e84df1a3-9998-4d37-a189-bf25048db069" />

■「カテゴリーごと」設定時の修正後

<img width="530" alt="スクリーンショット 2025-04-07 143043" src="https://github.com/user-attachments/assets/4e84b144-115c-4af7-9403-d229dc7a784a" />
