### PR TITLE
不具合報告の「タブ一覧」「カテゴリーごと」のとき、除外カテゴリーの投稿が除外されない不具合の修正対応後の「もっと見るボタン」の不具合修正とリファクタリング対応

### DIFF
--- a/lib/html-forms.php
+++ b/lib/html-forms.php
@@ -1160,7 +1160,7 @@ endif;
 
 //汎用エントリーウィジェットのタグ生成
 if ( !function_exists( 'generate_widget_entries_tag' ) ):
-function generate_widget_entries_tag($atts){
+function generate_widget_entries_tag($atts, $loop_index = 0){
   extract(shortcode_atts(array(
     'entry_count' => 5,
     'cat_ids' => array(),
@@ -1343,6 +1343,11 @@ function generate_widget_entries_tag($atts){
     'horizontal' => $horizontal,
   );
   $cards_classes = get_additional_widget_entry_cards_classes($atts);
+
+  // カウントを一意なキーで設定
+  $unique_count_key = 'count_' . $loop_index;
+  // カウントの初期値
+  $count = 0;
   ?>
   <div class="<?php echo $prefix; ?>-entry-cards widget-entry-cards no-icon cf<?php echo $cards_classes; ?>">
   <?php if ( $horizontal ) : ?>
@@ -1367,10 +1372,14 @@ function generate_widget_entries_tag($atts){
       );
     }
 
-    echo get_widget_entry_card_link_tag($atts); ?>
+    echo get_widget_entry_card_link_tag($atts);
+
+    set_query_var($unique_count_key, $count++); // 一意なキーでカウントを設定
+    ?>
   <?php endwhile;
   else :
     echo '<p>'.__( '記事は見つかりませんでした。', THEME_NAME ).'</p>';//見つからない時のメッセージ
+    set_query_var($unique_count_key, 0); // 記事がない場合は 0 を設定
   endif; ?>
   <?php wp_reset_postdata(); ?>
   <?php //wp_reset_query(); ?>

--- a/lib/html-forms.php
+++ b/lib/html-forms.php
@@ -1374,7 +1374,8 @@ function generate_widget_entries_tag($atts, $loop_index = 0){
 
     echo get_widget_entry_card_link_tag($atts);
 
-    set_query_var($unique_count_key, $count++); // 一意なキーでカウントを設定
+    $count++; // カウントをインクリメント
+    set_query_var($unique_count_key, $count); // 一意なキーでカウントを設定
     ?>
   <?php endwhile;
   else :

--- a/lib/html-forms.php
+++ b/lib/html-forms.php
@@ -1160,7 +1160,7 @@ endif;
 
 //汎用エントリーウィジェットのタグ生成
 if ( !function_exists( 'generate_widget_entries_tag' ) ):
-function generate_widget_entries_tag($atts, $loop_index = 0){
+function generate_widget_entries_tag($atts){
   extract(shortcode_atts(array(
     'entry_count' => 5,
     'cat_ids' => array(),
@@ -1343,11 +1343,6 @@ function generate_widget_entries_tag($atts, $loop_index = 0){
     'horizontal' => $horizontal,
   );
   $cards_classes = get_additional_widget_entry_cards_classes($atts);
-
-  // カウントを一意なキーで設定
-  $unique_count_key = 'count_' . $loop_index;
-  // カウントの初期値
-  $count = 0;
   ?>
   <div class="<?php echo $prefix; ?>-entry-cards widget-entry-cards no-icon cf<?php echo $cards_classes; ?>">
   <?php if ( $horizontal ) : ?>
@@ -1373,14 +1368,12 @@ function generate_widget_entries_tag($atts, $loop_index = 0){
     }
 
     echo get_widget_entry_card_link_tag($atts);
-
-    $count++; // カウントをインクリメント
-    set_query_var($unique_count_key, $count); // 一意なキーでカウントを設定
+    set_query_var('count', 1); // 記事がある場合は 1 を設定
     ?>
   <?php endwhile;
   else :
     echo '<p>'.__( '記事は見つかりませんでした。', THEME_NAME ).'</p>';//見つからない時のメッセージ
-    set_query_var($unique_count_key, 0); // 記事がない場合は 0 を設定
+    set_query_var('count', 0); // 記事がない場合は 0 を設定
   endif; ?>
   <?php wp_reset_postdata(); ?>
   <?php //wp_reset_query(); ?>

--- a/lib/page-settings/index-funcs.php
+++ b/lib/page-settings/index-funcs.php
@@ -364,6 +364,8 @@ function get_category_index_list_entry_card_tag($categories, $count){
     $count = 0;
   } else { // ここから記事が見つからなかった場合の処理
     cocoon_template_part('tmp/list-not-found-posts');
+    // 記事が見つからなかった場合はカウントを0にする
+    set_query_var('count', 0);
   }
   wp_reset_postdata();
   return ob_get_clean();

--- a/lib/page-settings/index-funcs.php
+++ b/lib/page-settings/index-funcs.php
@@ -342,7 +342,7 @@ function get_category_index_list_entry_card_tag($categories, $count){
 
   //カテゴリーの除外
   $exclude_category_ids = get_archive_exclude_category_ids();
-  if (!$categories && $exclude_category_ids && is_array($exclude_category_ids)) {
+  if ($exclude_category_ids && is_array($exclude_category_ids)) {
     $args += array(
       'category__not_in' => $exclude_category_ids,
     );

--- a/tmp/list-category-columns.php
+++ b/tmp/list-category-columns.php
@@ -76,16 +76,15 @@ $count = get_index_category_entry_card_count();
         <div class="list <?php echo $class; ?>">
           <?php
           //新着記事リストの作成
-          generate_widget_entries_tag($atts, $i);
+          generate_widget_entries_tag($atts);
           ?>
         </div><!-- .list -->
 
 
         <?php if ($cat = get_category($cat_id)): ?>
         <?php
-        // 一意なカウントを取得
-        $unique_count_key = 'count_' . $i;
-        $current_count = get_query_var($unique_count_key);
+        // カウントを取得
+        $current_count = get_query_var('count');
 
           // カウントが 0 より大きい場合のみ表示
           if ($current_count > 0): ?>

--- a/tmp/list-category-columns.php
+++ b/tmp/list-category-columns.php
@@ -76,14 +76,25 @@ $count = get_index_category_entry_card_count();
         <div class="list <?php echo $class; ?>">
           <?php
           //新着記事リストの作成
-          generate_widget_entries_tag($atts);
+          generate_widget_entries_tag($atts, $i);
           ?>
         </div><!-- .list -->
-        <?php if($cat = get_category($cat_id)): ?>
-          <div class="list-more-button-wrap">
+
+
+        <?php if ($cat = get_category($cat_id)): ?>
+        <?php
+        // 一意なカウントを取得
+        $unique_count_key = 'count_' . $i;
+        $current_count = get_query_var($unique_count_key);
+
+          // カウントが 0 より大きい場合のみ表示
+          if ($current_count > 0): ?>
+            <div class="list-more-button-wrap">
               <a href="<?php echo get_category_link($cat_id); ?>" class="list-more-button"><?php echo apply_filters('more_button_caption', __( 'もっと見る', THEME_NAME )); ?></a>
-          </div>
+            </div>
+          <?php endif; ?>
         <?php endif; ?>
+
       </div><!-- .list-column -->
       <?php endif; ?>
 

--- a/tmp/list-category.php
+++ b/tmp/list-category.php
@@ -42,11 +42,19 @@ $count = get_index_category_entry_card_count();
         <div class="<?php echo get_index_list_classes(); ?>">
           <?php echo get_category_index_list_entry_card_tag($cat_id, $count); ?>
         </div><!-- .list -->
-        <?php if($cat = get_category($cat_id)): ?>
-          <div class="list-more-button-wrap">
-              <a href="<?php echo get_category_link($cat_id); ?>" class="list-more-button"><?php echo apply_filters('more_button_caption', __( 'もっと見る', THEME_NAME )); ?></a>
-          </div>
-        <?php endif; ?>
+        <?php
+        // カテゴリ情報を取得
+        if ($cat = get_category($cat_id)) {
+            // count が 0 でない場合のみ「もっと見る」ボタンを表示
+            if (get_query_var('count') > 0): ?>
+                <div class="list-more-button-wrap">
+                    <a href="<?php echo get_category_link($cat_id); ?>" class="list-more-button">
+                        <?php echo apply_filters('more_button_caption', __('もっと見る', THEME_NAME)); ?>
+                    </a>
+                </div>
+            <?php endif;
+        }
+        ?>
       </div><!-- .list-category- -->
       <?php endif; ?>
     <?php endfor; ?>

--- a/tmp/list-new-entries.php
+++ b/tmp/list-new-entries.php
@@ -19,7 +19,13 @@ $count = get_index_new_entry_card_count();
   <div class="<?php echo get_index_list_classes(); ?>">
     <?php echo get_category_index_list_entry_card_tag(null, $count); ?>
   </div><!-- .list -->
+  <?php
+  // count が 0 でない場合のみ「もっと見る」ボタンを表示
+  if (get_query_var('count') > 0): ?>
   <div class="list-more-button-wrap">
       <a href="<?php echo trailingslashit(get_bloginfo('url')) ?>?cat=0" class="list-more-button"><?php echo apply_filters('more_button_caption', __( 'もっと見る', THEME_NAME )); ?></a>
   </div>
+  <?php
+  endif;
+  ?>
 </div><!-- .list-new-entries -->

--- a/tmp/list-tab-index.php
+++ b/tmp/list-tab-index.php
@@ -59,6 +59,8 @@ $cat_count = apply_filters('cocoon_index_max_category_tab_count', 3);
                 'order' => 'DESC',
                 //カテゴリーをIDで指定
                 'category' => $cat_id,
+                //除外カテゴリーがある場合は除外
+                'category__not_in' => get_archive_exclude_category_ids(),
                 //アーカイブに表示しないページのID
                 'post__not_in' =>  get_archive_exclude_post_ids(),
             );
@@ -84,6 +86,9 @@ $cat_count = apply_filters('cocoon_index_max_category_tab_count', 3);
                 <a href="<?php echo get_category_link($cat_id); ?>" class="list-more-button"><?php echo apply_filters('more_button_caption', __( 'もっと見る', THEME_NAME )); ?></a>
             </div>
         <?php endif; ?>
+        <?php else: ?>
+            <h2>NOT FOUND</h2>
+            <p>投稿が見つかりませんでした。</p>
         <?php endif; ?>
     </div>
     <?php endif; ?>


### PR DESCRIPTION
# 修正元のPR

https://github.com/xserver-inc/cocoon/pull/268

# 関連フォーラム

https://wp-cocoon.com/community/bugs/%e3%83%95%e3%83%ad%e3%83%b3%e3%83%88%e3%83%9a%e3%83%bc%e3%82%b8%e3%81%8c%e3%80%8c%e3%82%bf%e3%83%96%e4%b8%80%e8%a6%a7%e3%80%8d%e3%80%8c%e3%82%ab%e3%83%86%e3%82%b4%e3%83%aa%e3%83%bc%e3%81%94%e3%81%a8/#post-84691

# 本PRの目的

[こちらの不具合の件](https://github.com/xserver-inc/cocoon/pull/268)で修正後、「もっと見る」ボタンの表示において、「出力ページが1の場合に「もっと見る」ボタンが出力されない」という不具合があったため、こちらを修正

また、tmp/list-category-columns.phpとtmp/list-tab-index.phpにおいて、インデックス（一意なIDを出力）で処理させていた箇所を無くし、true/false形式にしてコードをシンプルにするリファクタリングの実施

# 修正内容

## 「もっと見る」ボタンの表示の修正

修正前では下図のように各カラムの記事ページ表示数が1件だった場合、本来表示されるはずの「もっと見る」ボタンが表示されない不具合がありましたが...

<img width="377" alt="スクリーンショット 2025-04-09 130514" src="https://github.com/user-attachments/assets/fc5cac47-ed95-4d60-a372-ce66bf92cb6f" />

本PRでの修正後は、下図のように表示されるように修正いたしました。

<img width="391" alt="スクリーンショット 2025-04-09 134826" src="https://github.com/user-attachments/assets/e646d381-f3c6-4c79-9441-a42ea51bdacf" />

## tmp/list-category-columns.phpとtmp/list-tab-index.phpにおいて、各カラムごとのインデックスを利用しての処理からtrue/falseでの処理へ修正してリファクタリング

下図のようなイメージで、可読性や保守性を高める目的で、今回追加していたインデックス処理を削除してコードをシンプルにいたしました。

<img width="532" alt="スクリーンショット 2025-04-09 154308" src="https://github.com/user-attachments/assets/9f831011-55c4-469d-9f8d-0a6525f8fed0" />

https://github.com/xserver-inc/cocoon/commit/282eb5e2f81e77f2dc9956dc55ee6e6790df0627#diff-4eb8121b22431a8363010400ce47d366bcc0798a9553a077

<img width="532" alt="スクリーンショット 2025-04-09 154324" src="https://github.com/user-attachments/assets/74c09a2b-a603-4d3c-956f-938b7f11ea37" />
b2ad05179d12e86e

https://github.com/xserver-inc/cocoon/commit/282eb5e2f81e77f2dc9956dc55ee6e6790df0627#diff-1e7f9eb40059ed778080035a009f7c12976cf171c74005d487f8bcc183dc09f3