### PR TITLE
不具合報告の「タブ一覧」「カテゴリーごと」のとき、除外カテゴリーの投稿が除外されない不具合の修正対応後の「もっと見るボタン」の不具合修正とリファクタリング対応

### DIFF
--- a/lib/html-forms.php
+++ b/lib/html-forms.php
@@ -1368,9 +1368,9 @@ function generate_widget_entries_tag($atts){
     }
 
     echo get_widget_entry_card_link_tag($atts);
-    set_query_var('count', 1); // 記事がある場合は 1 を設定
     ?>
   <?php endwhile;
+    set_query_var('count', 1); // 記事がある場合は 1 を設定
   else :
     echo '<p>'.__( '記事は見つかりませんでした。', THEME_NAME ).'</p>';//見つからない時のメッセージ
     set_query_var('count', 0); // 記事がない場合は 0 を設定

--- a/lib/html-forms.php
+++ b/lib/html-forms.php
@@ -1160,7 +1160,7 @@ endif;
 
 //汎用エントリーウィジェットのタグ生成
 if ( !function_exists( 'generate_widget_entries_tag' ) ):
-function generate_widget_entries_tag($atts, $loop_index = 0){
+function generate_widget_entries_tag($atts){
   extract(shortcode_atts(array(
     'entry_count' => 5,
     'cat_ids' => array(),
@@ -1343,11 +1343,6 @@ function generate_widget_entries_tag($atts, $loop_index = 0){
     'horizontal' => $horizontal,
   );
   $cards_classes = get_additional_widget_entry_cards_classes($atts);
-
-  // カウントを一意なキーで設定
-  $unique_count_key = 'count_' . $loop_index;
-  // カウントの初期値
-  $count = 0;
   ?>
   <div class="<?php echo $prefix; ?>-entry-cards widget-entry-cards no-icon cf<?php echo $cards_classes; ?>">
   <?php if ( $horizontal ) : ?>
@@ -1373,13 +1368,12 @@ function generate_widget_entries_tag($atts, $loop_index = 0){
     }
 
     echo get_widget_entry_card_link_tag($atts);
-
-    set_query_var($unique_count_key, $count++); // 一意なキーでカウントを設定
+    set_query_var('count', 1); // 記事がある場合は 1 を設定
     ?>
   <?php endwhile;
   else :
     echo '<p>'.__( '記事は見つかりませんでした。', THEME_NAME ).'</p>';//見つからない時のメッセージ
-    set_query_var($unique_count_key, 0); // 記事がない場合は 0 を設定
+    set_query_var('count', 0); // 記事がない場合は 0 を設定
   endif; ?>
   <?php wp_reset_postdata(); ?>
   <?php //wp_reset_query(); ?>

--- a/tmp/list-category-columns.php
+++ b/tmp/list-category-columns.php
@@ -76,16 +76,15 @@ $count = get_index_category_entry_card_count();
         <div class="list <?php echo $class; ?>">
           <?php
           //新着記事リストの作成
-          generate_widget_entries_tag($atts, $i);
+          generate_widget_entries_tag($atts);
           ?>
         </div><!-- .list -->
 
 
         <?php if ($cat = get_category($cat_id)): ?>
         <?php
-        // 一意なカウントを取得
-        $unique_count_key = 'count_' . $i;
-        $current_count = get_query_var($unique_count_key);
+        // カウントを取得
+        $current_count = get_query_var('count');
 
           // カウントが 0 より大きい場合のみ表示
           if ($current_count > 0): ?>


### PR DESCRIPTION
# 修正元のPR

https://github.com/xserver-inc/cocoon/pull/268

# 関連フォーラム

https://wp-cocoon.com/community/bugs/%e3%83%95%e3%83%ad%e3%83%b3%e3%83%88%e3%83%9a%e3%83%bc%e3%82%b8%e3%81%8c%e3%80%8c%e3%82%bf%e3%83%96%e4%b8%80%e8%a6%a7%e3%80%8d%e3%80%8c%e3%82%ab%e3%83%86%e3%82%b4%e3%83%aa%e3%83%bc%e3%81%94%e3%81%a8/
# 本PRの目的

[こちらの不具合の件](https://github.com/xserver-inc/cocoon/pull/268)で修正後、「もっと見る」ボタンの表示において、「出力ページが1の場合に「もっと見る」ボタンが出力されない」という不具合があったため、こちらを修正

また、tmp/list-category-columns.phpとtmp/list-tab-index.phpにおいて、インデックス（set_query_var()関数のデータ名に一意なIDを出力）で処理させていた箇所を無くし、true/false形式にしてコードをシンプルにするリファクタリングの実施

# 修正内容

## 「もっと見る」ボタンの表示の修正

修正前では下図のように各カラムの記事ページ表示数が1件だった場合、本来表示されるはずの「もっと見る」ボタンが表示されない不具合がありましたが...

<img width="377" alt="スクリーンショット 2025-04-09 130514" src="https://github.com/user-attachments/assets/fc5cac47-ed95-4d60-a372-ce66bf92cb6f" />

本PRでは、下図のように表示されるように修正いたしました。

<img width="391" alt="スクリーンショット 2025-04-09 134826" src="https://github.com/user-attachments/assets/e646d381-f3c6-4c79-9441-a42ea51bdacf" />

## tmp/list-category-columns.phpとtmp/list-tab-index.phpにおいて、各カラムごとにインデックスを利用してボタンをだし分ける処理から、true/falseでの処理へ修正してリファクタリング

下図のようなイメージで、可読性や保守性を高める目的で、今回追加していたインデックス処理を削除してコードをシンプルにいたしました。（スマートではないやり方で処理を追加しておりました...）

<img width="524" alt="スクリーンショット 2025-04-09 181029" src="https://github.com/user-attachments/assets/14bd3856-eb77-4bd5-893a-b5b09bf1b1ce" />

https://github.com/xserver-inc/cocoon/pull/270/files#diff-4eb8121b22431a8363010400ce47d366bcc0798a9553a077b2ad05179d12e86e

<img width="645" alt="スクリーンショット 2025-04-09 160902" src="https://github.com/user-attachments/assets/4703f375-42f8-4856-ba37-dbc24a702da5" />

https://github.com/xserver-inc/cocoon/pull/270/files#diff-1e7f9eb40059ed778080035a009f7c12976cf171c74005d487f8bcc183dc09f3