### PR TITLE
不具合報告の「タブ一覧」「カテゴリーごと」のとき、除外カテゴリーの投稿が除外されない不具合の修正対応後の追加の微調整

### DIFF
--- a/tmp/list-category-columns.php
+++ b/tmp/list-category-columns.php
@@ -83,11 +83,8 @@ $count = get_index_category_entry_card_count();
 
         <?php if ($cat = get_category($cat_id)): ?>
         <?php
-        // カウントを取得
-        $current_count = get_query_var('count');
-
           // カウントが 0 より大きい場合のみ表示
-          if ($current_count > 0): ?>
+          if (get_query_var('count') > 0): ?>
             <div class="list-more-button-wrap">
               <a href="<?php echo get_category_link($cat_id); ?>" class="list-more-button"><?php echo apply_filters('more_button_caption', __( 'もっと見る', THEME_NAME )); ?></a>
             </div>


### PR DESCRIPTION
# 修正元のPR

https://github.com/xserver-inc/cocoon/pull/268

# 関連するPR

https://github.com/xserver-inc/cocoon/pull/270

# 関連フォーラム

https://wp-cocoon.com/community/bugs/%e3%83%95%e3%83%ad%e3%83%b3%e3%83%88%e3%83%9a%e3%83%bc%e3%82%b8%e3%81%8c%e3%80%8c%e3%82%bf%e3%83%96%e4%b8%80%e8%a6%a7%e3%80%8d%e3%80%8c%e3%82%ab%e3%83%86%e3%82%b4%e3%83%aa%e3%83%bc%e3%81%94%e3%81%a8/

# 本PRの目的

以下の理由から、[こちらの修正後](https://github.com/xserver-inc/cocoon/pull/270)のtmp/list-category-columns.phpでのget_query_var('count')関数の値を変数に一旦代入する形から、get_query_var('count')を直接if文に記述して分岐させる形に修正する。

# 対応内容

tmp/list-category-columns.phpにて、以下のようにコードを修正いたしました。

<img width="722" alt="スクリーンショット 2025-04-10 190934" src="https://github.com/user-attachments/assets/25daa55e-f5c3-4165-bef7-28e77cd5653d" />