### PR TITLE
【不具合報告】get_posts()関数でループしていたところをWP_Queryに変更

### DIFF
--- a/tmp/list-tab-index.php
+++ b/tmp/list-tab-index.php
@@ -70,12 +70,15 @@ $cat_count = apply_filters('cocoon_index_max_category_tab_count', 3);
     <div class="tab-cont tb<?php echo $number; ?>">
       <?php
       $args = array(
-        'posts_per_page'   => get_option_posts_per_page(),
-        'orderby'          => !is_index_sort_orderby_date() ? get_index_sort_orderby() : 'date',
-        'order'            => 'DESC',
-        'cat'              => $cat_id,
-        'category__not_in' => get_archive_exclude_category_ids(),
-        'post__not_in'     => get_archive_exclude_post_ids(),
+        'post_type' => 'post'
+        'posts_per_page'      => get_option_posts_per_page(),
+        'orderby'             => !is_index_sort_orderby_date() ? get_index_sort_orderby() : 'date',
+        'order'               => 'DESC',
+        'cat'                 => $cat_id,
+        'category__not_in'    => get_archive_exclude_category_ids(),
+        'post__not_in'        => get_archive_exclude_post_ids(),
+        'ignore_sticky_posts' => true,
+        'no_found_rows'       => true,
       );
       $args = apply_filters('list_category_tab_args', $args, $cat_id);
       $query = new WP_Query($args);

--- a/tmp/list-tab-index.php
+++ b/tmp/list-tab-index.php
@@ -73,24 +73,24 @@ $cat_count = apply_filters('cocoon_index_max_category_tab_count', 3);
         'posts_per_page'   => get_option_posts_per_page(),
         'orderby'          => !is_index_sort_orderby_date() ? get_index_sort_orderby() : 'date',
         'order'            => 'DESC',
-        'category'         => $cat_id,
+        'cat'              => $cat_id,
         'category__not_in' => get_archive_exclude_category_ids(),
         'post__not_in'     => get_archive_exclude_post_ids(),
       );
       $args = apply_filters('list_category_tab_args', $args, $cat_id);
-      $posts = get_posts($args);
+      $query = new WP_Query($args);
 
-      if ($posts):
+      if ($query->have_posts()):
       ?>
         <div class="<?php echo $list_classes; ?>">
           <?php
           $count = 0;
-          foreach ($posts as $post):
-            setup_postdata($post);
+          while ($query->have_posts()):
+            $query->the_post();
             $count++;
             set_query_var('count', $count);
             cocoon_template_part('tmp/entry-card');
-          endforeach;
+          endwhile;
           wp_reset_postdata();
           ?>
         </div>

--- a/tmp/list-tab-index.php
+++ b/tmp/list-tab-index.php
@@ -70,7 +70,7 @@ $cat_count = apply_filters('cocoon_index_max_category_tab_count', 3);
     <div class="tab-cont tb<?php echo $number; ?>">
       <?php
       $args = array(
-        'post_type' => 'post'
+        'post_type'           => 'post',
         'posts_per_page'      => get_option_posts_per_page(),
         'orderby'             => !is_index_sort_orderby_date() ? get_index_sort_orderby() : 'date',
         'order'               => 'DESC',


### PR DESCRIPTION
# 対象のフォーラム

https://wp-cocoon.com/community/bugs/%E3%83%95%E3%83%AD%E3%83%B3%E3%83%88%E3%83%9A%E3%83%BC%E3%82%B8%E3%80%8C%E3%82%BF%E3%83%96%E4%B8%80%E8%A6%A7%E3%80%8D%E3%81%AE%E3%82%AB%E3%83%86%E3%82%B4%E3%83%AA%E3%83%BC%E3%81%AB%E9%9D%9E%E5%85%AC/

# 本PRの目的

前提として、WPログイン中にWordPressループでデフォルトで表示される非公開記事のお話になります。

Cocoon 設定の「インデックス」の「フロントページタイプ」にて、「タブ一覧」を設定したとき、「非公開」にしている記事ページが「新着記事タブ」では表示されるが、独自に設定したカテゴリーのタブでは非公開記事が表示されないため、表示されるようにしたい。

# 対応内容

- tmp/list-tab-index.phpにて、get_posts()関数で実装していたWordPressループを、WP_QueryでのWordPressループへ変更
- パラメーターをcategoryからcatへ変更し、カテゴリーごとに振り分けられるように修正

（今回もchu-yaさんのコードを参考にさせていただきました、いつもありがとうございます）

# 修正イメージ

■修正前

まず修正前のイメージをご説明します。

例えば、「コーヒー」カテゴリーを設定した記事を非公開状態にし、Cocoon設定の「インデックス」の「フロントページタイプ」で「タブ一覧」を設定したとします。

下図のように、修正前では、「新着記事」タブには非公開記事が表示されますが...

<img width="525" alt="スクリーンショット 2025-04-25 155333" src="https://github.com/user-attachments/assets/58ad0490-573e-4bce-aca6-eecb74feda16" />

「コーヒー」タブでは、非公開記事が表示されない状態となっておりました。
（ここでの例では、新着記事タブに表示されていた「コーヒー」カテゴリーを設定した「コーヒーを設定した記事」というタイトルの記事が一覧に表示されるべきでしたが、表示されませんでした）

<img width="518" alt="スクリーンショット 2025-04-25 155405" src="https://github.com/user-attachments/assets/f4afd7bc-ed96-44c5-b78a-5be6cdeca368" />

■修正後

修正後、下図のように「コーヒー」タブでも非公開記事が表示されるようにいたしました。

<img width="503" alt="スクリーンショット 2025-04-25 161925" src="https://github.com/user-attachments/assets/157ba8d9-99ed-44ba-be99-1d9bdbb181d6" />

「もっと見る」ボタンをクリック後のカテゴリーページと同等の表示にできたため、統一感が生まれたかとおもいます。

実装自体は、WP_Queryを利用して標準機能にのせる形で実装した形になります。
これにより、WP標準の「ログイン中は非公開記事が一覧に表示される」という動きを実現いたしました。

お手すきでご確認のほど、よろしくお願いいたします。

# 動作テスト

以下の内容で確認済みです。

- コードに無駄な重複などがないか
- 追加設定したカテゴリータブそれぞれにちゃんと非公開記事が表示されるか
- もっと見るボタンの遷移先が正しいか
- 管理画面「設定」の投稿数が正しく反映されるか
- レスポンシブ表示に影響はないか
- ログアウト後はちゃんと非公開記事が表示されないことを確認
- 他表示形式でも同様の挙動となっているか確認