### PR TITLE
tmp\list-tab-index.phpの「ignore_sticky_posts」を削除

### DIFF
--- a/tmp/list-tab-index.php
+++ b/tmp/list-tab-index.php
@@ -77,7 +77,6 @@ $cat_count = apply_filters('cocoon_index_max_category_tab_count', 3);
         'cat'                 => $cat_id,
         'category__not_in'    => get_archive_exclude_category_ids(),
         'post__not_in'        => get_archive_exclude_post_ids(),
-        'ignore_sticky_posts' => true,
         'no_found_rows'       => true,
       );
       $args = apply_filters('list_category_tab_args', $args, $cat_id);


### PR DESCRIPTION
# 対応内容

- tmp\list-tab-index.phpのWordPressループのパラメーターの「ignore_sticky_posts」を削除

# 対象のフォーラム

https://wp-cocoon.com/community/bugs/%E3%83%95%E3%83%AD%E3%83%B3%E3%83%88%E3%83%9A%E3%83%BC%E3%82%B8%E3%80%8C%E3%82%BF%E3%83%96%E4%B8%80%E8%A6%A7%E3%80%8D%E3%81%AE%E3%82%AB%E3%83%86%E3%82%B4%E3%83%AA%E3%83%BC%E3%81%AB%E9%9D%9E%E5%85%AC/

# 実装コードイメージ

以下のように、tmp\list-tab-index.phpのWordPressループのパラメーターの「ignore_sticky_posts」を削除し、不要なコードを削除いたしました。

<img width="661" alt="スクリーンショット 2025-04-30 205430" src="https://github.com/user-attachments/assets/fff99742-4c7d-490f-8fcc-8d5dd350d282" />

（chu-yaさん、貴重なご意見・ご指摘をいただきありがとうございます。）