### PR TITLE
bbPressが非アクティブな場合、特定のページテンプレートを非表示にする処理を追加

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -598,16 +598,55 @@ function hide_bbpress_templates_if_inactive( $page_templates ) {
     require_once ABSPATH . 'wp-admin/includes/plugin.php';
   }
 
-  // bbPressが非アクティブな場合、特定のページテンプレートを非表示にする
-  if ( !is_plugin_active( 'bbpress/bbpress.php' ) ) {
-    $templates_to_remove = [
-      'templates/page-create-topic.php',
-      'templates/page-front-forums.php',
-    ];
-    foreach ( $templates_to_remove as $template ) {
-      unset( $page_templates[ $template ] );
-    }
+  // bbPressがアクティブな場合は何もしない
+  if ( is_plugin_active( 'bbpress/bbpress.php' ) ) {
+    return $page_templates;
+  }
+
+  // 非アクティブな場合、非表示にしたいbbPressテンプレートのファイル名またはパスを定義
+  $bbpress_templates_to_remove = [
+    'templates/page-create-topic.php',
+    'templates/page-front-forums.php',
+  ];
+
+  // 現在のテンプレートから、上記で定義したbbPressテンプレートを非表示
+  foreach ( $bbpress_templates_to_remove as $template ) {
+    unset( $page_templates[ $template ] );
   }
 
   return $page_templates;
+}
+
+// bbPressが非アクティブな場合に、特定のbbPressテンプレートをpage.phpで上書きする
+add_filter( 'template_include', 'override_bbpress_templates_if_inactive' );
+function override_bbpress_templates_if_inactive( $template ) {
+  // is_plugin_activeが未定義の場合は読み込んで致命的なエラーを回避
+  if ( !function_exists( 'is_plugin_active' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/plugin.php';
+  }
+
+  // bbPressがアクティブな場合は何もしない
+  if ( is_plugin_active( 'bbpress/bbpress.php' ) ) {
+    return $template;
+  }
+
+  // 非アクティブな場合、上書きしたいbbPressテンプレートのファイル名またはパスを定義
+  // ここで定義されたテンプレートがもし現在読み込まれている場合、page.phpに切り替えます。
+  $bbpress_templates_to_override = [
+    'templates/page-create-topic.php',
+    'templates/page-front-forums.php',
+  ];
+
+  // 現在のテンプレートが、上書き対象のbbPressテンプレートのいずれかと一致するか確認
+  foreach ( $bbpress_templates_to_override as $bbpress_template ) {
+    if ( basename( $template ) === basename( $bbpress_template ) ) {
+      // WordPressのテンプレート階層に従い、page.phpを探して返す
+      $new_template = locate_template( 'page.php' );
+      if ( !empty( $new_template ) ) {
+          return $new_template; // page.phpが見つかったら、それを読み込む
+      }
+    }
+  }
+
+  return $template;
 }

--- a/functions.php
+++ b/functions.php
@@ -593,13 +593,8 @@ add_filter('cocoon_part__tmp/categories-tags', function($content) {
 // bbPressが非アクティブな場合、特定のページテンプレートを非表示にする
 add_filter( 'theme_page_templates', 'hide_bbpress_templates_if_inactive' );
 function hide_bbpress_templates_if_inactive( $page_templates ) {
-  // is_plugin_activeが未定義の場合は読み込んで致命的なエラーを回避
-  if ( !function_exists( 'is_plugin_active' ) ) {
-    require_once ABSPATH . 'wp-admin/includes/plugin.php';
-  }
-
-  // bbPressがアクティブな場合は何もしない
-  if ( is_plugin_active( 'bbpress/bbpress.php' ) ) {
+  // bbPressがインストールされている場合は何もしない
+  if ( is_bbpress_exist() ) {
     return $page_templates;
   }
 
@@ -620,13 +615,8 @@ function hide_bbpress_templates_if_inactive( $page_templates ) {
 // bbPressが非アクティブな場合に、特定のbbPressテンプレートをpage.phpで上書きする
 add_filter( 'template_include', 'override_bbpress_templates_if_inactive' );
 function override_bbpress_templates_if_inactive( $template ) {
-  // is_plugin_activeが未定義の場合は読み込んで致命的なエラーを回避
-  if ( !function_exists( 'is_plugin_active' ) ) {
-    require_once ABSPATH . 'wp-admin/includes/plugin.php';
-  }
-
-  // bbPressがアクティブな場合は何もしない
-  if ( is_plugin_active( 'bbpress/bbpress.php' ) ) {
+  // bbPressがインストールされている場合は何もしない
+  if ( is_bbpress_exist() ) {
     return $template;
   }
 

--- a/functions.php
+++ b/functions.php
@@ -589,3 +589,25 @@ add_filter('cocoon_part__tmp/categories-tags', function($content) {
 
   return $content;
 });
+
+// bbPressが非アクティブな場合、特定のページテンプレートを非表示にする
+add_filter( 'theme_page_templates', 'hide_bbpress_templates_if_inactive' );
+function hide_bbpress_templates_if_inactive( $page_templates ) {
+  // is_plugin_activeが未定義の場合は読み込んで致命的なエラーを回避
+  if ( !function_exists( 'is_plugin_active' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/plugin.php';
+  }
+
+  // bbPressが非アクティブな場合、特定のページテンプレートを非表示にする
+  if ( !is_plugin_active( 'bbpress/bbpress.php' ) ) {
+    $templates_to_remove = [
+      'templates/page-create-topic.php',
+      'templates/page-front-forums.php',
+    ];
+    foreach ( $templates_to_remove as $template ) {
+      unset( $page_templates[ $template ] );
+    }
+  }
+
+  return $page_templates;
+}


### PR DESCRIPTION
# 本PRの目的

bbPressプラグインを利用時に使用できる、固定ページのページテンプレート「bbPress - Create Topic」「bbPress - Forums(index)」がbbPress利用時でない場合にも表示されるため、以下のような事例を防ぎ、利便性を高める目的で、bbPressが有効化されていない場合はbbPress関連のページテンプレートを非表示にし、選択できないようにする。

https://wp-cocoon.com/community/postid/85217/

# ご意見をいただいたフォーラム

https://wp-cocoon.com/community/cocoon-theme/bbpress%e7%94%a8%e3%81%ae%e3%83%86%e3%83%b3%e3%83%97%e3%83%ac%e3%83%bc%e3%83%88%e3%81%ab%e3%81%a4%e3%81%84%e3%81%a6/

# 実装内容

・functions.phpにtheme_page_templatesフックを利用して、bbPressが有効化されていない場合はbbPress関連のページテンプレートを非表示とする処理を追加

# 今回の仕様

プラグイン管理画面にて、bbPressをインストール後「有効化した場合」に固定ページの「テンプレート」にて「bbPress - Create Topic」と「bbPress - Forums(index)」が従来通り選択可能となるようにいたしました。

bbPressを有効化していないデフォルトでは、「bbPress - Create Topic」と「bbPress - Forums(index)」は非表示となるようにいたしました。

# 実装イメージ

■ 修正前

これまでは下図のようにbbPressを有効化していない、もしくはそもそもインストールしていない場合は...

<img width="122" alt="スクリーンショット 2025-05-23 135608" src="https://github.com/user-attachments/assets/42fb3722-0284-4c18-9598-3cd544bd548d" />

下図のように、固定ページの「テンプレート」にて「bbPress - Create Topic」「bbPress - Forums(index)」が選択可能となっておりました。

<img width="320" alt="スクリーンショット 2025-05-23 135728" src="https://github.com/user-attachments/assets/4cafdeec-0536-459a-bb31-a6bfe336c08d" />

■ 修正後

修正後は、下図のようにbbPressを有効化していない、もしくはそもそもインストールしていない場合は...

<img width="122" alt="スクリーンショット 2025-05-23 135608" src="https://github.com/user-attachments/assets/42fb3722-0284-4c18-9598-3cd544bd548d" />

下図のように、固定ページの「テンプレート」にて「bbPress - Create Topic」「bbPress - Forums(index)」が非表示となり選択できないようにいたしました。

<img width="317" alt="スクリーンショット 2025-05-23 140016" src="https://github.com/user-attachments/assets/e536e67e-e0ba-49ac-b434-94bab33b361c" />

逆に、bbPressを有効化した場合...

<img width="144" alt="スクリーンショット 2025-05-23 140331" src="https://github.com/user-attachments/assets/ea95c9e8-dd4d-4aea-9fa1-737908466aa3" />

下図のように、「bbPress - Create Topic」「bbPress - Forums(index)」が表示されて選択可能となるようにいたしました。

<img width="323" alt="スクリーンショット 2025-05-23 140527" src="https://github.com/user-attachments/assets/fbe9253c-c64f-4b1e-9b64-03f7cb5a01bd" />

# 具体的な実装コード

functions.phpへ以下のコードを追加いたしました。

```
// bbPressが非アクティブな場合、特定のページテンプレートを非表示にする
add_filter( 'theme_page_templates', 'hide_bbpress_templates_if_inactive' );
function hide_bbpress_templates_if_inactive( $page_templates ) {
  // bbPressがインストールされている場合は何もしない
  if ( is_bbpress_exist() ) {
    return $page_templates;
  }

  // 非アクティブな場合、非表示にしたいbbPressテンプレートのファイル名またはパスを定義
  $bbpress_templates_to_remove = [
    'templates/page-create-topic.php',
    'templates/page-front-forums.php',
  ];

  // 現在のテンプレートから、上記で定義したbbPressテンプレートを非表示
  foreach ( $bbpress_templates_to_remove as $template ) {
    unset( $page_templates[ $template ] );
  }

  return $page_templates;
}
```

上記コードでは、WP標準のテンプレートタグであるis_plugin_active()関数を利用しており、データベーステーブル「wp_options」の「active_plugins」からデータ「bbpress/bbpress.php」を取得して判定するようになっております。

<img width="682" alt="スクリーンショット 2025-05-23 140427" src="https://github.com/user-attachments/assets/24aeb274-129d-49d7-8f4b-4b0fa6b35294" />

# 補足内容

■ クラシックエディタで確認

クラシックエディタでも、動作の方問題なさそうでした。

以下bbPressを無効化、アンインストールした場合。（デフォルト時）

<img width="193" alt="スクリーンショット 2025-05-23 142254" src="https://github.com/user-attachments/assets/9a9f494d-6664-4e79-810e-b3a738a9ed91" />

以下bbPressを有効化した場合。

<img width="166" alt="スクリーンショット 2025-05-23 142145" src="https://github.com/user-attachments/assets/f688fddc-76f0-409b-8078-106cc15f57c7" />

■ 独自に固定ページのPHPテンプレートを作成した場合

コード上ではbbPress関連のPHPテンプレートファイルを明示的にしているため、他独自に固定ページのPHPテンプレートを作成いただいても、影響がないようにいたしました。

例えば、子テーマにてpage-※※.phpのファイルを作成し、テンプレートを増やした場合...

<img width="116" alt="スクリーンショット 2025-05-23 183019" src="https://github.com/user-attachments/assets/dc67df16-7ca7-4d3d-8dd8-5a705a0089d7" />

以下のように影響を受けずに作成できます。

<img width="182" alt="スクリーンショット 2025-05-23 182024" src="https://github.com/user-attachments/assets/e6b24fa5-eb32-4fa4-a883-6b15b650844d" />

■ 子テーマにfront-page.phpを設置した場合の挙動

bbPressを有効化しつつ、front-page.phpをテーマファイルに設置した場合、「bbPress - Create Topic」や「bbPress - Forums(index)」を設定した固定ページを「ホームページの表示」にてトップページに設定した場合でも、front-page.phpが優先されます。

bbPress関連テンプレート「templates\page-create-topic.php」「templates\page-front-forums.php」をテーマファイル内に設置しててもしてなくても挙動は同じです。

つまり、front-page.phpが最優先されます。

■ 子テーマにbbPress関連テンプレート「templates\page-create-topic.php」「templates\page-front-forums.php」がある場合

bbPressを有効化しつつ、子テーマに「templates\page-create-topic.php」「templates\page-front-forums.php」がある場合、子テーマ側のテンプレートが優先されて出力されます。
※子テーマにfront-page.phpは作成しないものとします。