### PR TITLE
WordPress管理画面左メニュー「Cocoon設定」→「SNSフォロー」のSNSボタンの一覧に不足するSNS項目を追加

### DIFF
--- a/lib/page-settings/sns-follow-forms.php
+++ b/lib/page-settings/sns-follow-forms.php
@@ -79,9 +79,12 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
               <li><?php _e( 'Instagram', THEME_NAME ) ?></li>
               <li><?php _e( 'Pinterest', THEME_NAME ) ?></li>
               <li><?php _e( 'YouTube', THEME_NAME ) ?></li>
+              <li><?php _e( 'TikTok', THEME_NAME ) ?></li>
               <li><?php _e( 'LinkedIn', THEME_NAME ) ?></li>
               <li><?php _e( 'note', THEME_NAME ) ?></li>
+              <li><?php _e( 'SoundCloud', THEME_NAME ) ?></li>
               <li><?php _e( 'Flickr', THEME_NAME ) ?></li>
+              <li><?php _e( 'LINE@', THEME_NAME ) ?></li>
               <li><?php _e( 'Amazon欲しい物リスト', THEME_NAME ) ?></li>
               <li><?php _e( 'Twitch', THEME_NAME ) ?></li>
               <li><?php _e( '楽天ROOM', THEME_NAME ) ?></li>

--- a/lib/sns-follow.php
+++ b/lib/sns-follow.php
@@ -138,7 +138,7 @@ function user_contactmethods_custom($prof_items){
   $prof_items['misskey_url'] = __( 'Misskey URL', THEME_NAME );
   $prof_items['facebook_url'] = __( 'Facebook URL', THEME_NAME );
   //$prof_items['google_plus_url'] = __( 'Google+ URL', THEME_NAME );
-  $prof_items['hatebu_url'] = __( 'はてブ URL', THEME_NAME );
+  $prof_items['hatebu_url'] = __( 'はてなブックマーク URL', THEME_NAME );
   $prof_items['instagram_url'] = __( 'Instagram URL', THEME_NAME );
   $prof_items['pinterest_url'] = __( 'Pinterest URL', THEME_NAME );
   $prof_items['youtube_url'] = __( 'YouTube URL', THEME_NAME );
@@ -148,7 +148,7 @@ function user_contactmethods_custom($prof_items){
   $prof_items['soundcloud_url'] = __( 'SoundCloud URL', THEME_NAME );
   $prof_items['flickr_url'] = __( 'Flickr URL', THEME_NAME );
   $prof_items['line_at_url'] = __( 'LINE@ URL', THEME_NAME );
-  $prof_items['amazon_url'] = __( 'Amazon URL', THEME_NAME );
+  $prof_items['amazon_url'] = __( 'Amazon欲しい物リスト URL', THEME_NAME );
   $prof_items['twitch_url'] = __( 'Twitch URL', THEME_NAME );
   $prof_items['rakuten_room_url'] = __( '楽天 ROOM URL', THEME_NAME );
   $prof_items['slack_url'] = __( 'Slack URL', THEME_NAME );


### PR DESCRIPTION
# 本PRの目的

WordPress管理画面左メニューの「Cocoon設定」→「SNSフォロー」のSNS項目一覧の内容が、WordPress管理画面左メニュー「ユーザー」→「プロフィール」のSNS項目一覧と違いがあるため、差分を解消できればと思います。

![スクリーンショット 2025-07-08 100947](https://github.com/user-attachments/assets/4ba5a7f0-d6d3-4104-ae9d-3ca9db71d0df)

# 関連フォーラム

[SNSフォローとマニュアルの記載が異なる](https://wp-cocoon.com/community/typos/sns%e3%83%95%e3%82%a9%e3%83%ad%e3%83%bc%e3%81%a8%e3%83%9e%e3%83%8b%e3%83%a5%e3%82%a2%e3%83%ab%e3%81%ae%e8%a8%98%e8%bc%89%e3%81%8c%e7%95%b0%e3%81%aa%e3%82%8b/)

# 対応内容

WordPress管理画面左メニューの「Cocoon設定」→「SNSフォロー」のSNS項目一覧に以下の項目を追加いたしました。

- TikTok
- SoundCloud
- LINE@

■ 修正前

<img width="812" alt="スクリーンショット 2025-07-08 100947" src="https://github.com/user-attachments/assets/594f78cf-2ecc-4a07-a833-846a86da63c0" />

■ 修正後

![スクリーンショット 2025-07-08 101654](https://github.com/user-attachments/assets/1057cff3-a4aa-474b-8467-a76105227c83)

修正後は以下の「ユーザー」→「プロフィール」の内容に合わせました。

![スクリーンショット 2025-07-08 101959](https://github.com/user-attachments/assets/0b6ad02c-6bb2-4c44-a5e7-fca7189ad4b2)

# 今回のご対応にあたって念のためご確認

一点だけご確認なのですが、「Cocoon設定」→「SNSフォロー」のSNS項目一覧と「ユーザー」→「プロフィール」のSNS項目一覧の「項目名の表記」に関して若干の違いがあるかと思いますが、例えば「プロフィール」のSNS項目一覧を「SNSフォロー」のSNS項目一覧と表記を統一させるなどの対応は必要でしょうか？

例えば、下図のような違いになります。

![スクリーンショット 2025-07-08 133215](https://github.com/user-attachments/assets/28b81b14-abb2-444f-a218-0498f73ffc35)

ただ、こちら文字数などの問題等で最適化いただいている認識でして、修正提案というよりかは、必要であればご対応いたします、というニュアンスになります！

もし必要であればお気軽にお申しつけください。

お手すきでご確認のほど、よろしくお願いいたします。