### PR TITLE
スキン「おでかけ」のプロフィールの吹き出しのしっぽの位置がすこし真ん中からず入れているため真ん中になるように調整

### DIFF
--- a/skins/skin-ganchan01/style.css
+++ b/skins/skin-ganchan01/style.css
@@ -4,7 +4,6 @@
   背景画像ソースURL http://www.colourlovers.com/pattern/1301223/One_fish_two_fish
   Skin URI: https://aruru.co.jp/cocoon03/
   Author: がんちゃん
-  Author URI: https://ganchan.info/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-ganchan01.png
   Version: 0.0.1
   Priority: 9910002000

--- a/skins/skin-ganchan02/style.css
+++ b/skins/skin-ganchan02/style.css
@@ -4,7 +4,6 @@
   背景画像ソースURL http://www.colourlovers.com/pattern/2866736/vintage_flowers
   Skin URI: https://aruru.co.jp/cocoon03/
   Author: がんちゃん
-  Author URI: https://ganchan.info/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-ganchan02.png
   Version: 0.0.1
   Priority: 9910002000

--- a/skins/skin-ganchan03/style.css
+++ b/skins/skin-ganchan03/style.css
@@ -4,7 +4,6 @@
   背景画像ソースURL http://www.colourlovers.com/pattern/2866736/vintage_flowers
   Skin URI: https://aruru.co.jp/cocoon03/
   Author: がんちゃん
-  Author URI: https://ganchan.info/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-ganchan03.png
   Version: 0.0.1
   Priority: 9910002000

--- a/skins/skin-ganchan11/style.css
+++ b/skins/skin-ganchan11/style.css
@@ -414,7 +414,7 @@ body.public-page,.content .main, .navi {
   width: 0;
   height: 0;
    position: absolute;
-    left: -.7em;
+    left: -13px;
     display: inline-block;
     border-top: 15px solid transparent;
     border-right: 15px solid #666;
@@ -426,7 +426,7 @@ body.public-page,.content .main, .navi {
     border-right: 15px solid transparent;
     border-bottom: 15px solid #666;
     border-left: 15px solid transparent;
-    top: -1.6em;
+    top: -28px;
     left: 50%;
     transform: translateX(-50%);
 }

--- a/skins/skin-ganchan11/style.css
+++ b/skins/skin-ganchan11/style.css
@@ -437,8 +437,7 @@ body.public-page,.content .main, .navi {
   	padding:10px;
   }
   .author-content:before{
-  	top: 80px;
-      left: 25%;
+  	top: 40px;
   }
 }
 

--- a/skins/skin-ganchan11/style.css
+++ b/skins/skin-ganchan11/style.css
@@ -3,7 +3,6 @@
   Description: 女性が春色のスプリングコートを羽織っておでかけするイメージで作りました。ファッション・女性向けコンテンツにいかがでしょうか。
   Skin URI: https://aruru.co.jp/cocoon02/
   Author: がんちゃん
-  Author URI: https://ganchan.info/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-ganchan11.png
   Version: 0.0.1
   Priority: 9910001000

--- a/skins/skin-ganchan11/style.css
+++ b/skins/skin-ganchan11/style.css
@@ -428,7 +428,8 @@ body.public-page,.content .main, .navi {
     border-bottom: 15px solid #666;
     border-left: 15px solid transparent;
     top: -1.6em;
-    left: calc(46%);
+    left: 50%;
+    transform: translateX(-50%);
 }
 
 

--- a/skins/skin-ganchan12/style.css
+++ b/skins/skin-ganchan12/style.css
@@ -416,7 +416,7 @@ body.public-page,.content .main, .navi {
   width: 0;
   height: 0;
    position: absolute;
-    left: -.7em;
+    left: -13px;
     display: inline-block;
     border-top: 15px solid transparent;
     border-right: 15px solid #666;
@@ -428,7 +428,7 @@ body.public-page,.content .main, .navi {
     border-right: 15px solid transparent;
     border-bottom: 15px solid #666;
     border-left: 15px solid transparent;
-    top: -1.6em;
+    top: -28px;
     left: 50%;
     transform: translateX(-50%);
 }

--- a/skins/skin-ganchan12/style.css
+++ b/skins/skin-ganchan12/style.css
@@ -430,7 +430,8 @@ body.public-page,.content .main, .navi {
     border-bottom: 15px solid #666;
     border-left: 15px solid transparent;
     top: -1.6em;
-    left: calc(46%);
+    left: 50%;
+    transform: translateX(-50%);
 }
 
 

--- a/skins/skin-ganchan12/style.css
+++ b/skins/skin-ganchan12/style.css
@@ -3,7 +3,6 @@
   Description: 女性が春色のスプリングコートを羽織っておでかけするイメージで作りました。ファッション・女性向けコンテンツにいかがでしょうか。
   Skin URI: https://aruru.co.jp/cocoon02/
   Author: がんちゃん
-  Author URI: https://ganchan.info/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-ganchan12.png
   Version: 0.0.1
   Priority: 9910001000

--- a/skins/skin-ganchan12/style.css
+++ b/skins/skin-ganchan12/style.css
@@ -439,8 +439,7 @@ body.public-page,.content .main, .navi {
   	padding:10px;
   }
   .author-content:before{
-  	top: 80px;
-      left: 25%;
+  	top: 40px;
   }
 }
 

--- a/skins/skin-ganchan13/style.css
+++ b/skins/skin-ganchan13/style.css
@@ -417,7 +417,7 @@ body.public-page,.content .main, .navi {
   width: 0;
   height: 0;
    position: absolute;
-    left: -.7em;
+    left: -13px;
     display: inline-block;
     border-top: 15px solid transparent;
     border-right: 15px solid #666;
@@ -429,7 +429,7 @@ body.public-page,.content .main, .navi {
     border-right: 15px solid transparent;
     border-bottom: 15px solid #666;
     border-left: 15px solid transparent;
-    top: -1.6em;
+    top: -28px;
     left: 50%;
     transform: translateX(-50%);
 }

--- a/skins/skin-ganchan13/style.css
+++ b/skins/skin-ganchan13/style.css
@@ -431,7 +431,8 @@ body.public-page,.content .main, .navi {
     border-bottom: 15px solid #666;
     border-left: 15px solid transparent;
     top: -1.6em;
-    left: calc(46%);
+    left: 50%;
+    transform: translateX(-50%);
 }
 
 @media screen and (max-width: 480px){

--- a/skins/skin-ganchan13/style.css
+++ b/skins/skin-ganchan13/style.css
@@ -3,7 +3,6 @@
   Description: 女性が春色のスプリングコートを羽織っておでかけするイメージで作りました。ファッション・女性向けコンテンツにいかがでしょうか。
   Skin URI: https://aruru.co.jp/cocoon02/
   Author: がんちゃん
-  Author URI: https://ganchan.info/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-ganchan13.png
   Version: 0.0.1
   Priority: 9910001000

--- a/skins/skin-ganchan13/style.css
+++ b/skins/skin-ganchan13/style.css
@@ -439,8 +439,7 @@ body.public-page,.content .main, .navi {
   	padding:10px;
   }
   .author-content:before{
-  	top: 80px;
-      left: 25%;
+  	top: 40px;
   }
 }
 

--- a/skins/skin-ganchan21/style.css
+++ b/skins/skin-ganchan21/style.css
@@ -3,7 +3,6 @@
   Description: 旅ブログ専用スキンです。旅行写真が美しく見えるように工夫しています。
   Skin URI: https://aruru.co.jp/cocoon01/
   Author: がんちゃん
-  Author URI: https://ganchan.info/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/skin-ganchan21.png
   Version: 0.0.1
   Priority: 9910000000


### PR DESCRIPTION
@yhira
わいひらさん、お疲れ様です。
本PRの対応が完了いたしましたので、お手すきでご確認のほどよろしくお願いいたします！

# 本PRの目的

スキン「おでかけ」シリーズの「ピンク」「ブルー」「レモン」のプロフィールの吹き出しのしっぽの位置がすこし真ん中からず入れているため、真ん中になるように調整できればと思います。
また、あわせて他微修正もご対応いたします。

# 対応内容

- スキン「おでかけ」の「ピンク」「ブルー」「レモン」のプロフィールの吹き出しのしっぽの位置を真ん中にくるようにCSSを調整
- WordPress管理画面「Cocoon設定」→「スキン」→「スキン一覧」の [作者: ○○]のリンクがリンク切れのためリンクを削除
- 2カラム時のレスポンシブの吹き出しのしっぽの位置を調整

# 対象のフォーラム内容

[スキン「おでかけ」のプロフィール情報の吹き出しが左にずれている](https://wp-cocoon.com/community/skin-bugs/%e3%82%b9%e3%82%ad%e3%83%b3%e3%80%8c%e3%81%8a%e3%81%a7%e3%81%8b%e3%81%91%e3%80%8d%e3%81%ae%e3%83%97%e3%83%ad%e3%83%95%e3%82%a3%e3%83%bc%e3%83%ab%e6%83%85%e5%a0%b1%e3%81%ae%e5%90%b9%e3%81%8d%e5%87%ba/)

# 修正イメージ

以下のイメージで修正いたしました。
いずれも修正前では吹き出しのしっぽの位置が若干右に配置されていることと思います。

## プロフィールのしっぽの位置調整

### おでかけピンクの場合

■ 修正前

![スクリーンショット 2025-07-14 134533](https://github.com/user-attachments/assets/daa9b02d-e3f7-4823-9aa9-e524fb19ae77)

■ 修正後

<img width="185" height="207" alt="スクリーンショット 2025-07-14 134917" src="https://github.com/user-attachments/assets/f6f1bb93-bda3-40c5-9841-62bd75370256" />

### おでかけブルーの場合

■ 修正前

![スクリーンショット 2025-07-14 135026](https://github.com/user-attachments/assets/b01005e3-7d79-4afc-abd5-458569a4545b)

■ 修正後

<img width="171" height="203" alt="スクリーンショット 2025-07-14 135116" src="https://github.com/user-attachments/assets/4c95e0bc-bfef-4c72-ac24-267f4255f078" />

### おでかけレモンの場合

■ 修正前

![スクリーンショット 2025-07-14 135305](https://github.com/user-attachments/assets/9f1478fe-0118-4923-bd80-539c0fd96dc7)

■ 修正後

<img width="172" height="209" alt="スクリーンショット 2025-07-14 135348" src="https://github.com/user-attachments/assets/7bfd3a9d-fcbf-4c7b-b8e5-da1e3e8e01b0" />

##  管理画面「Cocoon設定」→「スキン」→「スキン一覧」の [作者: ○○]のリンクを削除

■ 修正前

[作者: ○○]のリンクをクリックすると、リンク切れとなります。

![スクリーンショット 2025-07-14 143236](https://github.com/user-attachments/assets/cb1412fd-e151-4170-a727-1984589c3aab)

■ 修正後

<img width="220" height="131" alt="スクリーンショット 2025-07-14 151022" src="https://github.com/user-attachments/assets/972690e1-f8b7-4454-bf34-4611c0bbd611" />

## 2カラム時のレスポンシブの吹き出しのしっぽの位置を調整

以下あわせてご対応いたしました。

### おでかけピンク

■ 修正前

![スクリーンショット 2025-07-15 114814](https://github.com/user-attachments/assets/cfd170db-f0c7-43ec-86e5-0d4e6b7beb9a)

■ 修正後

![スクリーンショット 2025-07-15 114248](https://github.com/user-attachments/assets/ab3e8f5d-c734-465f-ae01-8fe521183f01)

### おでかけブルー

■ 修正前

![スクリーンショット 2025-07-15 114419](https://github.com/user-attachments/assets/11f9fbc4-0b3f-4eea-87a8-75134ad69ef0)

■ 修正後

![スクリーンショット 2025-07-15 114447](https://github.com/user-attachments/assets/33bb1bce-d754-451e-9bb7-64b6e49bdfb7)

### おでかけレモン

■ 修正前

![スクリーンショット 2025-07-15 114620](https://github.com/user-attachments/assets/f1c2653f-1511-418f-9f19-899b01324931)

■ 修正後

![スクリーンショット 2025-07-15 114550](https://github.com/user-attachments/assets/ffa304fb-b9b0-45f1-92b6-b8eb4edb5f65)
