### PR TITLE
スキン「イノセンス」のプロフィールの画像背景に不要な枠がつくため調整

### DIFF
--- a/skins/skin-innocence/style.css
+++ b/skins/skin-innocence/style.css
@@ -637,10 +637,6 @@ button#comment-reply-btn {
 	color: #777;
 }
 
-.author-thumb img {
-	border: 3px solid #fff;
-}
-
 .nwa .author-box {
 	padding: 10px 0 0;
 }

--- a/skins/skin-innocence/style.css
+++ b/skins/skin-innocence/style.css
@@ -637,10 +637,6 @@ button#comment-reply-btn {
 	color: #777;
 }
 
-.author-thumb img {
-	border: 3px solid #fff;
-}
-
 .nwa .author-box {
 	padding: 10px 0 0;
 }
@@ -651,11 +647,7 @@ button#comment-reply-btn {
 	z-index: 1;
 }
 
-.nwa .author-box .author-thumb img {
-	border: none;
-}
-
-.author-thumb:before {
+.nwa .author-box .author-thumb:before {
 	content: "";
 	position: absolute;
 	width: calc(100% + 20px);

--- a/skins/skin-innocence/style.css
+++ b/skins/skin-innocence/style.css
@@ -637,6 +637,10 @@ button#comment-reply-btn {
 	color: #777;
 }
 
+.profile-block-box .author-thumb img {
+	border: 3px solid #fff;
+}
+
 .nwa .author-box {
 	padding: 10px 0 0;
 }

--- a/skins/skin-innocence/style.css
+++ b/skins/skin-innocence/style.css
@@ -637,7 +637,7 @@ button#comment-reply-btn {
 	color: #777;
 }
 
-.profile-block-box .author-thumb img {
+.author-thumb img {
 	border: 3px solid #fff;
 }
 
@@ -649,6 +649,10 @@ button#comment-reply-btn {
 	position: relative;
 	margin-top: 17px;
 	z-index: 1;
+}
+
+.nwa .author-box .author-thumb img {
+	border: none;
 }
 
 .author-thumb:before {


### PR DESCRIPTION
わいひらさん
お疲れ様です。
お手数ですが、以下お手すきでプルリクのご確認お願いいたします。

# 本PRの目的

スキン「イノセンス」のプロフィールの画像背景に不要な枠がつくため調整できればと思います。

# 対応内容

- スキン「イノセンス」のプロフィールの画像背景に不要な枠がつくため、枠がつかないようにCSSコードを調整

# 対象のフォーラム内容

[スキン「イノセンス 」のプロフィールに不要な枠が付く](https://wp-cocoon.com/community/skin-bugs/%e3%82%b9%e3%82%ad%e3%83%b3%e3%80%8c%e3%82%a4%e3%83%8e%e3%82%bb%e3%83%b3%e3%82%b9-%e3%80%8d%e3%81%ae%e3%83%97%e3%83%ad%e3%83%95%e3%82%a3%e3%83%bc%e3%83%ab%e3%81%ab%e4%b8%8d%e8%a6%81%e3%81%aa%e6%9e%a0/)

# 修正イメージ

以下のイメージで修正いたしました。

■ 修正前

<img width="452" height="338" alt="スクリーンショット 2025-07-14 153742" src="https://github.com/user-attachments/assets/ea7a400d-92b4-4f49-b400-9d6ae1d1fd8e" />

下図のようにプロフィール画像の背景に四角の枠線が表示されておりました。

![スクリーンショット 2025-07-14 101317](https://github.com/user-attachments/assets/d2adfb77-5280-428f-9472-7ec069227351)

■ 修正後

修正後は下図のように枠線が表示されないように調整いたしました。

<img width="244" height="245" alt="スクリーンショット 2025-07-14 101212" src="https://github.com/user-attachments/assets/78a455a9-9938-4648-af53-d9df6f40d715" />

# 補足

chu-yaさんよりご提供いただいたコードを参考にさせていただき、修正を行いました。ご提供いただき誠にありがとうございます。
私の方ですこしアレンジを加えまして、プロフィールブロックの画像の背景の四角形の枠が消えないように調整いたしました。

![スクリーンショット 2025-07-14 104511](https://github.com/user-attachments/assets/2a195a69-7650-496e-ae17-74c5ac392ac0)