### PR TITLE
スキン「イノセンス」のエントリーカードのサムネイル画像の上の余白を削除

### DIFF
--- a/skins/skin-innocence/style.css
+++ b/skins/skin-innocence/style.css
@@ -78,6 +78,16 @@ body {
 	transform: translateY(-2px);
 }
 
+.entry-card-thumb {
+	/* サムネイルの上の余白をなくす */
+	margin-top: 0;
+}
+
+.entry-card-thumb img {
+	/* サムネイルの上の角を丸くする */
+	border-radius: 3px 3px 0 0;
+}
+
 .entry-card-title {
 	color: #5a5a5a;
 	/*見出しの色*/

--- a/skins/skin-innocence/style.css
+++ b/skins/skin-innocence/style.css
@@ -60,6 +60,7 @@ body {
 	border-radius: 3px;
 	padding: 0;
 	margin-bottom: 35px;
+	overflow: hidden;
 }
 
 @media screen and (max-width: 480px) {
@@ -81,11 +82,6 @@ body {
 .entry-card-thumb {
 	/* サムネイルの上の余白をなくす */
 	margin-top: 0;
-}
-
-.entry-card-thumb img {
-	/* サムネイルの上の角を丸くする */
-	border-radius: 3px 3px 0 0;
 }
 
 .entry-card-title {


### PR DESCRIPTION
わいひらさん
お疲れ様です。
以下PRを作成いたしましたので、お手すきでご確認のほどよろしくお願いいたします。

# 本PRの目的

Cocoon本体側のCSSの影響によってスキン「イノセンス」のエントリーカードのサムネイル画像の上に余白が3pxほど空いてしまっているため、こちらを余白が無くなるように調整できればと思います。

# 対応内容

- スキン「イノセンス」のエントリーカードのサムネイル画像の上の余白を削除

# 対象のフォーラム内容

[スキン「イノセンス 」のエントリーカード上に余白ができる](https://wp-cocoon.com/community/skin-bugs/%e3%82%b9%e3%82%ad%e3%83%b3%e3%80%8c%e3%82%a4%e3%83%8e%e3%82%bb%e3%83%b3%e3%82%b9-%e3%80%8d%e3%81%ae%e3%82%a8%e3%83%b3%e3%83%88%e3%83%aa%e3%83%bc%e3%82%ab%e3%83%bc%e3%83%89%e4%b8%8a%e3%81%ab%e4%bd%99/)

# 修正イメージ

以下のイメージで修正いたしました。

■ 修正前

修正前では、下図のように3pxほど余白が空いておりました。

![スクリーンショット 2025-07-14 155416](https://github.com/user-attachments/assets/365daa3c-e9f2-4e1e-b431-7f3b4e82ec1b)

■ 修正後

当PRを反映後、下図のように余白が無くなり、画像上の左右の角を角丸化（3px）いたしました。

<img width="445" height="311" alt="スクリーンショット 2025-07-14 155347" src="https://github.com/user-attachments/assets/59d00b50-597f-4e55-9f50-20d45d21ad69" />

# 補足

影響元のCSSは以下の箇所になるかと思いますため、念のため補足させていただきます。

ファイルの場所：（Cocoon）style.css

```
.carousel-entry-card-thumb, .related-entry-card-thumb, .widget-entry-card-thumb, .entry-card-thumb {
  float: left;
  margin-top: 3px;
  position: relative;
  margin-bottom: 0.4em;
}
```

![スクリーンショット 2025-07-14 160047](https://github.com/user-attachments/assets/0b52f91c-a1bd-465c-a1e7-ccbc433c9806)
