### PR TITLE
イノセンススキンのプロフィール画像のCSSを微調整

### DIFF
--- a/skins/skin-innocence/style.css
+++ b/skins/skin-innocence/style.css
@@ -657,8 +657,7 @@ button#comment-reply-btn {
 	content: "";
 	position: absolute;
 	width: calc(100% + 20px);
-	height: 200px;
-	height: calc(100% + 14px);
+	height: calc(100% + 20px);
 	background-color: #fff;
 	border-radius: 50%;
 	transform: translate(-10px, -10px);


### PR DESCRIPTION
# 本PRの目的

イノセンススキンのプロフィールの画像をCSSで正方形になるように調整し、CSSのheightの重複を調整できればとおもいます。

# 関連issues

[スキン「イノセンス 」のプロフィールに不要な枠が付く](https://wp-cocoon.com/community/skin-bugs/%E3%82%B9%E3%82%AD%E3%83%B3%E3%80%8C%E3%82%A4%E3%83%8E%E3%82%BB%E3%83%B3%E3%82%B9-%E3%80%8D%E3%81%AE%E3%83%97%E3%83%AD%E3%83%95%E3%82%A3%E3%83%BC%E3%83%AB%E3%81%AB%E4%B8%8D%E8%A6%81%E3%81%AA%E6%9E%A0/)

# 調整イメージ

「skins\skin-innocence\style.css」の656行目付近の「.nwa .author-box .author-thumb:before」の「height: 200px;」を削除し、「height: calc(100% + 14px);」の14pxを20pxへ調整いたしました。

■ 調整前

```
.nwa .author-box .author-thumb:before {
	content: "";
	position: absolute;
	width: calc(100% + 20px);
	height: 200px;
	height: calc(100% + 14px);
	background-color: #fff;
	border-radius: 50%;
	transform: translate(-10px, -10px);
	z-index: -1;
}
```

■ 調整後

以下のように調整いたしました。

```
.nwa .author-box .author-thumb:before {
	content: "";
	position: absolute;
	width: calc(100% + 20px);
	height: calc(100% + 20px);
	background-color: #fff;
	border-radius: 50%;
	transform: translate(-10px, -10px);
	z-index: -1;
}
```

# 修正後イメージ

修正後、下図のように「120 × 120」で正方形となるように調整いたしました。

<img width="209" height="166" alt="スクリーンショット 2025-07-22 182625" src="https://github.com/user-attachments/assets/13e4b207-5876-4e12-83e5-86a20a9899a2" />

また、CSSのheightの重複も削除し改善いたしました。

![スクリーンショット 2025-07-22 184839](https://github.com/user-attachments/assets/7d7f0e32-beb0-48e1-adea-701a082f3a3a)

また、モバイルも下図のように反映されております。

<img width="200" height="287" alt="スクリーンショット 2025-07-22 182803" src="https://github.com/user-attachments/assets/43be490d-0461-45fe-9f32-b34b01f1a553" />