### PR TITLE
WordPress管理画面左メニュー「外観」の「ヘッダー」を削除

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -411,6 +411,14 @@ function remove_widgets_block_editor() {
 }
 endif;
 
+//カスタムヘッダーサポートの削除
+add_action( 'after_setup_theme', 'remove_custom_header_support' );
+if ( !function_exists( 'remove_custom_header_support' ) ):
+function remove_custom_header_support() {
+  remove_theme_support( 'custom-header' );
+}
+endif;
+
 //FAQブロック
 //参考：SILKスキンのコード（ろこさん作成）
 //URL：https://dateqa.com/cocoon/


### PR DESCRIPTION
# 本PRの目的

WordPress管理画面左メニュー「外観」→「ヘッダー」を削除できればと思います。

理由としては、フォーラムにてご指摘いただいた通り、カスタマイザーにはメニューに「ヘッダー」は存在せず、カスタマイザーメニュー内にヘッダーに関する項目が見当たらない？といった具合にユーザーを混乱させてしまう可能性を防げることと思いました。

# 対象フォーラム

[管理画面の[外観]→[ヘッダー]について](https://wp-cocoon.com/community/cocoon-theme/%e7%ae%a1%e7%90%86%e7%94%bb%e9%9d%a2%e3%81%ae%e5%a4%96%e8%a6%b3%e2%86%92%e3%83%98%e3%83%83%e3%83%80%e3%83%bc%e3%81%ab%e3%81%a4%e3%81%84%e3%81%a6/)

# 対応内容

- functions.phpにてremove_theme_support( 'custom-header' )関数をafter_setup_themeフックで実行し、「外観」→「ヘッダー」の項目を削除

# 修正前の挙動のイメージ

修正前の挙動としては、「外観」の「カスタマイズ」へ遷移しても「ヘッダー」へ遷移しても同様の挙動となることが確認できました。

■ WordPress管理画面左メニュー「外観」→「カスタマイズ」を選択後の挙動

<img width="836" height="386" alt="スクリーンショット 2025-08-08 101734" src="https://github.com/user-attachments/assets/cb2eb36c-3b71-4cb1-bd80-8cc51a2974c9" />

■ WordPress管理画面左メニュー「外観」→「ヘッダー」を選択後の挙動

<img width="835" height="388" alt="スクリーンショット 2025-08-08 101804" src="https://github.com/user-attachments/assets/7b7ca174-41af-4fdc-a90e-bfcd4945eb61" />

# 修正イメージ

■ 修正前

![スクリーンショット 2025-08-08 095734](https://github.com/user-attachments/assets/0266ca25-63cb-4338-b8a0-a993e9964687)

■ 修正後

<img width="204" height="160" alt="スクリーンショット 2025-08-08 095909" src="https://github.com/user-attachments/assets/e2726841-123c-4a0d-abba-14831e900a53" />