### PR TITLE
新着記事ショートコードの重複しているdateオプションを削除

### DIFF
--- a/lib/shortcodes.php
+++ b/lib/shortcodes.php
@@ -56,7 +56,6 @@ function new_entries_shortcode($atts) {
     'ex_posts' => null,
     'ex_cats' => null,
     'ordered_posts' => null,
-    'date' => 0,
   ), $atts, 'new_list'));
 
   //countオプションに異常値が入っていた場合


### PR DESCRIPTION
# 本PRの目的

新着記事ショートコード「new_list」のdateオプションがコード上重複しているため、片方を削除して修正できればと思います。

![スクリーンショット 2025-08-27 173706](https://github.com/user-attachments/assets/f0c32589-2d4e-4a59-987d-116cf28f5a96)

ファイルの場所：lib\shortcodes.php
関数名：new_entries_shortcode

また、あわせてマニュアルを更新できればと思います。