### PR TITLE
スキンsilkのブロックエディタとフロントの見出しの表示に差分があるため一致させるように調整

### DIFF
--- a/skins/silk/functions.php
+++ b/skins/silk/functions.php
@@ -171,11 +171,6 @@ class Skin_Silk_Functions {
       define('SILK_SWITCH', false);
     }
 
-    //見出しナンバリング
-    if (!defined('SILK_COUNTER')) {
-      define('SILK_COUNTER', true);
-    }
-
     //縦型ブログカード
     if (!defined('SILK_BLOGCARD')) {
       define('SILK_BLOGCARD', true);
@@ -294,7 +289,7 @@ class Skin_Silk_Functions {
     #index-tab-4:checked ~ .index-tab-buttons .index-tab-button[for="index-tab-4"],
     .cat-label,
     .pagination .current,
-    .article h2 span::after,
+    .article h2::after,
     blockquote p:first-of-type::before,
     .blogcard-label,
     .timeline-item::before,
@@ -311,7 +306,7 @@ class Skin_Silk_Functions {
     .slick-dots li button:before,
     .slick-dots li.slick-active button:before,
     .archive-title span,
-    .article h4 > span::before,
+    .article h4::before,
     .article h5,
     .sidebar h2,
     .sidebar h3,
@@ -710,7 +705,7 @@ class Skin_Silk_Functions {
       $font   = 'font-family: "Font Awesome 5 Free";';
       $weight = 'font-weight: 900;';
     }
-    echo '.article h4 > span::before,
+    echo '.article h4::before,
     blockquote p:first-of-type::before,
     ul.is-style-link li a::before,
     ol.is-style-link li a::before,
@@ -737,18 +732,6 @@ class Skin_Silk_Functions {
       .header-container.fixed-header {
         padding-top: 0;
         border-top: 3px solid '.$color.';
-      }';
-    }
-
-    //見出しカウント
-    if (SILK_COUNTER) {
-      echo '.entry-content {
-        counter-reset: h2;
-      }
-
-      .entry-content h2 > span::before {
-        content: counter(h2, decimal) ". ";
-        counter-increment: h2;
       }';
     }
 

--- a/skins/silk/style.css
+++ b/skins/silk/style.css
@@ -917,13 +917,14 @@ a.page-numbers {
   border-radius: 0;
 }
 
-.article h2 > span::after {
+.article h2::after {
   position: absolute;
   content: "";
   width: 20%;
   height: 4px;
   left: 0;
   bottom: -4px;
+  background-color: #e57373;
 }
 
 .article h3 {
@@ -931,6 +932,7 @@ a.page-numbers {
   font-size: 1.25em;
   border-width: 0 0 0 5px;
   border-style: solid;
+  border-color: #e57373;
 }
 
 .article h4 {
@@ -939,9 +941,15 @@ a.page-numbers {
   border-width: 0;
 }
 
-.article h4 > span::before {
+.article h4::before {
   content: "\f061";
   margin-right: 0.5em;
+  color: #e57373;
+  font-family: FontAwesome;
+}
+
+.article h5 {
+  color: #e57373;
 }
 
 .article h5,
@@ -949,6 +957,16 @@ a.page-numbers {
   padding: 0;
   font-size: 1em;
   border-width: 0;
+}
+
+/* 見出しカウント */
+.article {
+  counter-reset: h2;
+}
+
+.article h2::before {
+  content: counter(h2, decimal) ". ";
+  counter-increment: h2;
 }
 
 /* 引用 */


### PR DESCRIPTION
# 本PRの目的

スキンsilkのブロックエディタとフロントの見出しの表示に差分があるため、表示が一致するように調整できればと思います。
ブロックエディタ側に適切なCSSコードがあたってないため、エディタ側へ調整を加えられればと思います。

# 対象フォーラム

[SILKの見出し表示がエディターとフロントで異なる](https://wp-cocoon.com/community/skin-bugs/silk%e3%81%ae%e8%a6%8b%e5%87%ba%e3%81%97%e8%a1%a8%e7%a4%ba%e3%81%8c%e3%82%a8%e3%83%87%e3%82%a3%e3%82%bf%e3%83%bc%e3%81%a8%e3%83%95%e3%83%ad%e3%83%b3%e3%83%88%e3%81%a7%e7%95%b0%e3%81%aa%e3%82%8b/)

# 対応内容

- h2タグのカウンターをエディタ側にも適用させる修正
- エディタ側のh2タグとh4タグをフロント表示と一致させる修正

# 修正前イメージ

■ ブロックエディタ

下図のように、ブロックエディタに設置したh2タグとh4タグに不具合が確認できました。

h2タグ→下の色付きアクセントバーが無い
h4タグ→文字手前の矢印が無い

![スクリーンショット 2025-09-08 182440](https://github.com/user-attachments/assets/672c2da1-233d-41ba-84f4-8f336b113bc8)

# 修正後イメージ

以下それぞれのパターンで確認しましたが、表示に問題なさそうでした。

- ブロックエディタの場合
- ブロックエディタでCocoon設定のサイトキーカラーを変更した場合
- クラシックエディタの場合
- クラシックエディタでCocoon設定のサイトキーカラーを変更した場合

## ブロックエディタの場合

■ ブロックエディタ

<img width="887" height="434" alt="スクリーンショット 2025-09-08 183108" src="https://github.com/user-attachments/assets/d976c8f6-2158-4963-a9b6-42835568cf55" />

■ フロント表示

<img width="860" height="412" alt="スクリーンショット 2025-09-08 181735" src="https://github.com/user-attachments/assets/4fd4d66c-2893-4ab8-8802-a353f6b93aa0" />

## ブロックエディタでCocoon設定のサイトキーカラーを変更した場合

また、下図のようにCocoon設定のサイトキーカラーを変更した場合も、以下のように調整されます。

<img width="322" height="242" alt="スクリーンショット 2025-09-08 183204" src="https://github.com/user-attachments/assets/d22e1ad2-40f6-4d44-812d-c24aa0bdc850" />

■ ブロックエディタ

<img width="884" height="431" alt="スクリーンショット 2025-09-08 183358" src="https://github.com/user-attachments/assets/fb3f4fb5-ec46-4ebe-873f-ead2b54d8548" />

■ フロント表示

<img width="856" height="413" alt="スクリーンショット 2025-09-08 183327" src="https://github.com/user-attachments/assets/03959a47-1274-4460-a86b-242591fe0d18" />

## クラシックエディタの場合

<img width="855" height="360" alt="スクリーンショット 2025-09-09 165131" src="https://github.com/user-attachments/assets/3e4ca1ef-c86a-46bc-94ea-f912ebb169ae" />

## クラシックエディタでCocoon設定のサイトキーカラーを変更した場合

<img width="864" height="397" alt="スクリーンショット 2025-09-09 165452" src="https://github.com/user-attachments/assets/9ca292e4-2c2a-477c-8eeb-2594bcedbdb7" />

# 補足

## エディタ側で一部CSSが適用されない件について

※仕様の認識を整理するため、念のため記載させていただきます。

### h2タグのカウンターをエディタ側にも適用させる修正

functions.phpで制御していた見出しカウンターのCSSをstyle.cssに移行しました。従来はフロントでしかスタイルが適用されませんでしたが、この変更により、フロントとエディタの表示が常に一致するようになるかと思います。

↓ functions.phpから削除

https://github.com/xserver-inc/cocoon/pull/292/files#diff-a439affd182f02dbf7a46633ed3b1f7b3a8a5c4b8b3a723ba65ab579fbaefdbdL174

https://github.com/xserver-inc/cocoon/pull/292/files#diff-a439affd182f02dbf7a46633ed3b1f7b3a8a5c4b8b3a723ba65ab579fbaefdbdL743

↓ style.cssへ移行

https://github.com/xserver-inc/cocoon/pull/292/files#diff-b2e07234a48bd8687997c88c8068c64db09eea5946aeb99acdf041b6e1a78ab5R962

■ 修正前の問題点

functions.php内のcss_custom()関数からCSSを出力する従来の方法では、以下の問題がありました。

- フロントエンド: スタイルは常に適用される。
- エディタ: uploads/cocoon-resources/css-cache/css-custom.cssというキャッシュファイルが生成された後でないと、スタイルが適用されない。

このキャッシュファイルはCocoon設定を保存するまで生成されないため、それまではエディタ上で表示のズレが生じていました。

■ 解決策

上記問題点を解決するため、CSSの記述をstyle.cssに移行することで、キャッシュの有無にかかわらず、フロントエンドとエディタの両方にスタイルが常時読み込まれるようになり、この問題が解消されるかと思います。

### エディタ側のh2タグとh4タグをフロント表示と一致させる修正

エディタ側のh2タグとh4タグをフロント表示と一致させる対応として、silkスキンのstyle.cssにて以下の対応を行いました。

- spanタグをセレクタから削除
- article h2～h5を見直して、「background-color: #e57373;」など不足しているコードを追加

これによりspanタグの有無に関係なく、見出しタグのデザインの崩れを解決いたしました。

また、style.cssよりもfunctions.phpのcss_custom()関数のCSSが優先されるため、例えばCocoon設定「全体」の「サイトキーカラー」を変更した場合でも、サイトキーカラーの色が正しく反映されます。