### PR TITLE
スキンsilk独自の「バックアップ」→「オプション設定」のリンク切れのリンクテキストを調整

### DIFF
--- a/skins/silk/functions.php
+++ b/skins/silk/functions.php
@@ -1244,8 +1244,6 @@ class Skin_Silk_Functions {
                       <input type="submit" class="button" value="設定の追加" />
                       <input type="hidden" name="<?php echo self::HIDDEN; ?>" value="<?php echo wp_create_nonce('skin-option'); ?>">
                       <?php generate_tips_tag('スキンのオプション設定が書かれたJSONファイルを選択し、「設定の追加」ボタンを押してください。JSONファイルの作成方法はファイル名を除き、スキン制御に従います。'.get_help_page_tag('https://wp-cocoon.com/option-json/')); ?>
-                      <p><span class="fa fa-arrow-right" aria-hidden="true"></span> <a href="https://dateqa.com/cocoon/#silk" target="_blank" rel="noopener">設定ファイルをダウンロードする</a></p>
-                      <p><span class="fa fa-arrow-right" aria-hidden="true"></span> <a href="https://dateqa.com/cocoon/#option" target="_blank" rel="noopener">オプションの詳しい設定方法を見る</a></p>
                     </form>
                   </td>
                 </tr>


### PR DESCRIPTION
# 本PRの目的

スキンsilkの独自機能である「バックアップ」→「オプション設定」のリンク切れのリンクテキストを調整できればと思います。

# 対象フォーラム

[SLIKのオプション設定画面の説明リンク先が不正サイトとなる](https://wp-cocoon.com/community/skin-bugs/slik%e3%81%ae%e3%82%aa%e3%83%97%e3%82%b7%e3%83%a7%e3%83%b3%e8%a8%ad%e5%ae%9a%e7%94%bb%e9%9d%a2%e3%81%ae%e8%aa%ac%e6%98%8e%e3%83%aa%e3%83%b3%e3%82%af%e5%85%88%e3%81%8c%e4%b8%8d%e6%ad%a3%e3%82%b5/)

# 対応内容

- リンク切れを起こしているリンクテキストを削除
- silkのマニュアルページを修正

# 修正前イメージ

現状下図の箇所の2点のリンクがリンク切れを起こしていることを確認いたしました。

![スクリーンショット 2025-09-08 185124](https://github.com/user-attachments/assets/fd514b1e-3129-4514-bc48-8f995997cc3e)

# 修正後イメージ

![スクリーンショット 2025-09-08 185024](https://github.com/user-attachments/assets/58285d69-dd56-41ed-8c94-05ba1f543d2b)

# 追加対応

今回の修正に伴って、以下のSILKスキンのページもリンク切れを起こしているため、調整を検討できればと思います。

https://wp-cocoon.com/silk/