### PR TITLE
投稿がNO IMAGEのとき、カテゴリーのアイキャッチが表示されない不具合を修正

### DIFF
--- a/lib/page-settings/image-funcs.php
+++ b/lib/page-settings/image-funcs.php
@@ -200,6 +200,9 @@ if ( !function_exists( 'get_image_sized_url' ) ):
 function get_image_sized_url($url, $w, $h){
   $ext = get_extention($url);
   $sized_url = str_replace('.'.$ext, '-'.$w.'x'.$h.'.'.$ext, $url);
+  if (!file_exists(url_to_local($sized_url))) {
+    $sized_url = $url;
+  }
   return apply_filters('get_image_sized_url', $sized_url, $url, $w, $h);
 }
 endif;


### PR DESCRIPTION
# 本PRの目的

投稿ページにてアイキャッチを未設定にしておき、その投稿ページに紐づけたカテゴリーにアイキャッチを設定した場合、通常であればCocoonの仕様上インデックス（記事一覧）にてその設定したカテゴリーのアイキャッチが表示されるはずが、表示されない不具合がみられたため、修正できればと思います。

# 対象フォーラム

[投稿がNO IMAGEのとき、カテゴリーのアイキャッチが表示されない](https://wp-cocoon.com/community/bugs/%e6%8a%95%e7%a8%bf%e3%81%8cno-image%e3%81%ae%e3%81%a8%e3%81%8d%e3%80%81%e3%82%ab%e3%83%86%e3%82%b4%e3%83%aa%e3%83%bc%e3%81%ae%e3%82%a2%e3%82%a4%e3%82%ad%e3%83%a3%e3%83%83%e3%83%81%e3%81%8c%e8%a1%a8/)

# 対応内容

- lib/page-settings/image-funcs.phpの画像URLから指定サイズのURL生成する関数であるget_image_sized_url()関数の処理に、サムネイル画像ファイルの有無を確認し、無ければ元ファイルを返す処理を追加

# 不具合イメージ

今回は、投稿ページのアイキャッチ画像は未設定で、その投稿ページに紐づけたカテゴリーのアイキャッチに設定している画像が、リンク切れを起こして表示されない不具合を確認いたしました。

![スクリーンショット 2025-09-24 162431](https://github.com/user-attachments/assets/338eccf6-4294-4bfa-8e3f-8acb1cf66222)

不具合の流れとしては以下になるかと思います。

1. カテゴリーアイキャッチ画像として（例：200×150）のサイズの画像をアップロードする
2. add_image_size()で320×180が定義されているが、元画像が小さいため生成されない
3. get_image_sized_url()で320×180のURLを生成するが、そもそも2によりファイルが存在しない
4. 存在しないURLがそのまま返される
5. 画像が表示されない

# 修正イメージ

以下のように生成された画像のファイル有無の確認の処理をget_image_sized_url()関数に追加することで、以下のように不具合を解決できるかと思います。

1. file_exists()チェックにより、存在しないサムネイルを検出
2. 元画像にフォールバックすることで、小さくても画像が表示される
3. カテゴリーアイキャッチが確実に表示されるようになる

```
  if (!file_exists(url_to_local($sized_url))) {
    $sized_url = $url;
  }
```

https://github.com/xserver-inc/cocoon/pull/297/files

これにより、下図のようにフォールバックされた場合、カテゴリーに設定したアイキャッチの元画像が表示されるようになります。

![スクリーンショット 2025-09-24 170641](https://github.com/user-attachments/assets/9085d6cd-49c4-4b9d-8373-feaefd261188)

# 考えられる原因

今回の原因について、念のためおまとめいたしました。

## 根本的な原因

「そもそも処理上期待された正しいサイズ（ファイル名）の画像が生成されない」という根本的な原因によって不具合が起こっている認識です。
具体的にいうと「【元のファイル名】-320x320.png」のようなファイル名の画像が生成されないことにより、今回の不具合が起こりました。

![スクリーンショット 2025-09-24 161714](https://github.com/user-attachments/assets/ee165762-a5c4-4aaa-93d4-11ebaa7b54f1)

大前提として、add_image_size()関数では、仕様として設定した横幅より小さい画像を扱う場合、その設定した横幅で新しいサイズの画像は生成されません。（画像の画質の低下を防ぐため）

Cocoonでは[/lib/settings.php](https://github.com/xserver-inc/cocoon/blob/5e6d4d0a11dbcd4891fc1bd0d6c8c03b83ed57c7/lib/settings.php#L59)にて「add_image_size('thumb320', 320, 180, true);」によって、幅320px、高さ180pxで画像を切り抜く新しい画像サイズをWordPressに登録しております。

つまり、このadd_image_size()で追加した画像サイズである「thumb320」では、横幅320pxより小さい画像をカテゴリーのアイキャッチに設定した場合、「【元のファイル名】-320x320.png」のファイル名形式で画像が生成されない挙動となるかと思います。

ちなみに横幅320pxで生成される画像のアスペクト比は、Cocoon設定「画像」→「サムネイル画像」で設定した項目によって変わる仕様となっております。（例：「デフォルト」なら横幅320px・高さ180px、「黄金比」なら横幅320px・高さ198px、「正方形」なら横幅320px・高さ320pxの画像を生成）

上記のことから、「そもそも正しいサイズの画像が生成されない」という挙動が起こってしまい、フロント表示上リンク切れが起こってしまっている認識です。

## バグ発生の流れ（ご参考）

1. 投稿ページにアイキャッチを未設定にして、その投稿に紐づけたカテゴリーに横幅320px未満の小さなアイキャッチ画像を設定する
3. この時横幅320px以下なので、add_imag_size()関数の設定によって期待される正しい画像ファイルが生成されない
4. インデックスにてget_entry_card_no_image_tag()関数が呼ばれてアイキャッチ画像表示を処理
5. get_entry_card_no_image_tag()関数ではget_no_image_320x180_url()関数によって320x320の画像URLを返すが、そのget_no_image_320x180_url()関数にて設置しているget_sized_no_image_urlフックにget_categorized_no_image_url()関数をフックさせて、カテゴリーのアイキャッチを取得し、320x320を付加したカテゴリーアイキャッチ画像のURLを返す
6. 結果的に320x320を付加したカテゴリーアイキャッチ画像が無いため、リンク切れが起こりなにも表示されない

## インデックスでのアイキャッチ画像表示の仕様で認識していること

インデックス（記事一覧）のサムネイル画像の表示の仕様は以下になるかと思います。

- 投稿ページのアイキャッチが最優先されて表示
- 投稿ページのアイキャッチが無く、紐づけたカテゴリーのアイキャッチがあれば次に優先されて表示
- Cocoon設定の「画像」→「NO IMAGE設定」は投稿ページのアイキャッチ、カテゴリーのアイキャッチの設定が無い場合に表示

# 処理上の関連ファイル

- lib\page-settings\image-funcs.php
- lib\page-settings\image-forms.php
- lib\entry-card.php
- lib\settings.php

# コード上での原因箇所

フロントの出力として、紐づけたカテゴリーのアイキャッチ画像が表示される以下の箇所で、そもそも存在しない画像URLが返されていることによってリンク切れが起こりアイキャッチが表示されない挙動となっているかと思います。

https://github.com/xserver-inc/cocoon/blob/5e6d4d0a11dbcd4891fc1bd0d6c8c03b83ed57c7/lib/page-settings/image-funcs.php#L298

```
// get_image_sized_url()でfile_exists()チェックが無い
function get_categorized_no_image_url($url, $width, $height, $id, $is_singular){
  // ...
  $url = get_image_sized_url($cat_url, $width, $height);
  // ↑ 存在しない画像URLが返される可能性
}
```

そのため、以下のように修正したイメージとなります。

https://github.com/xserver-inc/cocoon/pull/297/files#diff-f398932f5a597e1653cd8dcff0296677793661ff54712b9ee1b14ddccf9f5675R200

```
// 今回の修正でget_image_sized_url()でfile_exists()チェックを追加
function get_image_sized_url($url, $w, $h){
  $sized_url = str_replace('.'.$ext, '-'.$w.'x'.$h.'.'.$ext, $url);
  if (!file_exists(url_to_local($sized_url))) {
    $sized_url = $url; // 元画像にフォールバック
  }
  return $sized_url;
}
```