### PR TITLE
「プロフィール」ブロックのプロフィール設定画面へのリンクが不正となる不具合を修正

### DIFF
--- a/lib/html-forms.php
+++ b/lib/html-forms.php
@@ -1556,7 +1556,7 @@ function generate_author_box_tag($id = null, $label = null, $is_image_circle = 0
             echo wpautop(__( '未登録ユーザーです。ログインして、Cocoon設定の保存ボタンを押してください。', THEME_NAME ));
           }
         } elseif (is_user_logged_in()) {
-          echo wpautop(__( 'プロフィール内容は管理画面から変更可能です→', THEME_NAME ).'<a href="' . esc_url(home_url() . '/wp-admin/user-edit.php?user_id='.get_the_author_meta( 'ID' )).'">'.__( 'プロフィール設定画面', THEME_NAME ).'</a><br>'.__( '※このメッセージは、ログインユーザーにしか表示されません。', THEME_NAME ));
+          echo wpautop(__( 'プロフィール内容は管理画面から変更可能です→', THEME_NAME ).'<a href="' . esc_url(home_url() . '/wp-admin/user-edit.php?user_id='.$user_id).'">'.__( 'プロフィール設定画面', THEME_NAME ).'</a><br>'.__( '※このメッセージは、ログインユーザーにしか表示されません。', THEME_NAME ));
         }
         ?>
 


### PR DESCRIPTION
# 本PRの目的

現在ログインしているユーザー（ユーザーＡ）とは別のユーザー（ユーザーＢ）の設定をしたプロフィールブロックを追加したとき、ログイン中にフロントにて表示されるプロフィールブロックのユーザーのプロフィール設定画面へのリンクが、その設定したユーザー（ユーザーＡ）のリンクになってしまう不具合を修正できればと思います。

# 対象フォーラム

[「プロフィール」ブロックのプロフィール設定画面へのリンクが不正となる](https://wp-cocoon.com/community/bugs/%e3%80%8c%e3%83%97%e3%83%ad%e3%83%95%e3%82%a3%e3%83%bc%e3%83%ab%e3%80%8d%e3%83%96%e3%83%ad%e3%83%83%e3%82%af%e3%81%ae%e3%83%97%e3%83%ad%e3%83%95%e3%82%a3%e3%83%bc%e3%83%ab%e8%a8%ad%e5%ae%9a%e7%94%bb/)

# 対応内容

- lib/html-forms.phpの1559行目get_the_author_meta( 'ID' )を、$user_idに修正

# 修正後イメージ

下図にて、ユーザー名「takazawa」にてログイン中とします。

ログイン時にて、プロフィールブロックにて表示される「プロフィール設定画面」テキストリンクが、修正前ではログイン中のユーザー「takazawa」のプロフィール管理画面へ遷移されてしまいますが、修正後はそのプロフィールブロックにて設定したユーザー（下図の例では「takazawa_sub」）のプロフィール画面へ遷移できたら修正完了の認識です。

つまり、プロフィールブロックにて設定したユーザーのプロフィール画面へ遷移させるように調整しております。

![スクリーンショット 2025-09-19 160008](https://github.com/user-attachments/assets/62c7b075-c436-45c2-9db9-b0eceb2adb9f)

# 動作確認

管理者権限（administrator）のユーザーでログインし、以下のすべての権限のそれぞれのユーザーを設定したときに、それぞれのユーザーへの正しいプロフィール編集画面へ遷移することを確認できました。

- 管理者
- 編集者
- 投稿者
- 寄稿者
- 購読者

管理者以外の権限では、ユーザーデータの編集権限は無い認識なので、管理者としてログインしているときのみ編集可能で正しい認識です。

お手すきで、ご確認のほどよろしくお願いいたします。