### PR TITLE
lib\shortcodes.phpでの重複しているnew_entries_shortcode()関数のパラメータ「'author' => $author,」を削除＋その他不要な箇所を調整

### DIFF
--- a/lib/shortcodes.php
+++ b/lib/shortcodes.php
@@ -113,7 +113,6 @@ function new_entries_shortcode($atts) {
     'ex_posts' => $exclude_post_ids,
     'ex_cats' => $exclude_cat_ids,
     'ordered_posts' => $ordered_post_ids,
-    'author' => $author,
   );
   ob_start();
   generate_widget_entries_tag($atts);

--- a/lib/shortcodes.php
+++ b/lib/shortcodes.php
@@ -720,31 +720,6 @@ function get_recommend_cards_tag($atts){
 }
 endif;
 
-//ナビメニューショートコード
-//参考：https://www.orank.net/1972
-add_shortcode('navi', 'get_ord_navi_card_list_tag');
-if ( !function_exists( 'get_ord_navi_card_list_tag' ) ):
-function get_ord_navi_card_list_tag($atts){
-  extract(shortcode_atts(array(
-    'name' => '', // メニュー名
-    'type' => '',
-    'bold' => 1,
-    'arrow' => 1,
-    'class' => null,
-  ), $atts, 'navi'));
-  $atts = array(
-    'name' => $name,
-    'type' => $type,
-    'bold' => $bold,
-    'arrow' => $arrow,
-    'class' => $class,
-  );
-  $tag = get_navi_card_list_tag($atts);
-
-  return apply_filters('get_ord_navi_card_list_tag', $tag);
-}
-endif;
-
 //ボックスメニューショートコード
 add_shortcode('box_menu', 'get_box_menu_tag');
 if ( !function_exists( 'get_box_menu_tag' ) ):


### PR DESCRIPTION
# 本PRの目的

lib\shortcodes.phpにて新着記事ショートコードのnew_entries_shortcode()関数のパラメータ「'author' => $author,」が重複しているため、調整できればと思います。
また、ナビメニューショートコードのget_ord_navi_card_list_tag()関数も重複しているため削除し、他含め全体的にコードをチェックしつつ調整できればと思います。

# 対応内容

- lib\shortcodes.phpにて新着記事ショートコードのnew_entries_shortcode()関数のパラメータ「'author' => $author,」が重複しているため片方を削除して調整
- lib\shortcodes.phpにてナビメニューショートコードのget_ord_navi_card_list_tag()関数自体が2つあって重複しているため片方を削除して調整

# 修正前イメージ

修正前のイメージとして、以下のような箇所が発見しましたため、それぞれ調整を行いました。

## 新着記事ショートコード関数の重複した'author' => $author,の片方を削除

下図のように重複する部分がありましたため、片方を削除し調整いたしました。

![スクリーンショット 2025-10-06 181715](https://github.com/user-attachments/assets/62a1e9f7-e71b-4302-9510-41f4eeb19c3c)

修正後は以下のように削除して調整いたしました。

https://github.com/xserver-inc/cocoon/pull/300/files#diff-0f63ec91f1603ad47a354c6abeb892754e68780d94dc87c274235104adb1c811L116

## ナビメニューショートコードの関数で同一の記述が2つあったため片方を削除

![スクリーンショット 2025-10-07 162925](https://github.com/user-attachments/assets/118f3b88-3fe7-467e-949c-160243e99b86)

修正後は以下のように削除して調整いたしました。

https://github.com/xserver-inc/cocoon/pull/300/files#diff-0f63ec91f1603ad47a354c6abeb892754e68780d94dc87c274235104adb1c811L724

動作確認に関してはいずれも問題なさそうで、例えば`[new_list author=3]`のように著者IDを設定したショートコードを設置した場合に、動作に問題ありませんでした。
また、ナビカードショートコードの方も、問題なく動作していることも確認いたしました。

<img width="474" height="242" alt="スクリーンショット 2025-10-07 163531" src="https://github.com/user-attachments/assets/a775f2c9-9bb4-4d50-b07f-f8413a642b22" />
