### PR TITLE
外部ブログカードのサムネイルが表示されない不具合を修正

### DIFF
--- a/lib/blogcard-out.php
+++ b/lib/blogcard-out.php
@@ -187,6 +187,7 @@ function url_to_external_ogp_blogcard_tag($url){
           $ogp->image = $res;
         }
       }
+
       if ( isset( $ogp->title ) && $ogp->title )
         $title = $ogp->title;//タイトルの取得
 
@@ -229,6 +230,7 @@ function url_to_external_ogp_blogcard_tag($url){
   if ($domain_style === 'name' && !empty($ogp->site_name)) {
     $domain = $ogp->site_name; // OGPのサイト名を優先
   }
+
 
   //og:imageが相対パスのとき
   if(!$image || (strpos($image, '//') === false) || (is_ssl() && (strpos($image, 'https:') === false))){    // //OGPのURL情報があるか

--- a/lib/blogcard-out.php
+++ b/lib/blogcard-out.php
@@ -206,19 +206,15 @@ function url_to_external_ogp_blogcard_tag($url){
   } elseif ( $ogp == 'error' ) {
     //前回取得したとき404ページだったら何も出力しない
   } else {
-    // キャッシュされたOGPデータの処理
+
     if ( isset( $ogp->title ) && $ogp->title )
       $title = $ogp->title;//タイトルの取得
 
     if ( isset( $ogp->description ) && $ogp->description )
       $snippet = $ogp->description;//ディスクリプションの取得
 
-    // キャッシュされた画像URLを取得（_valuesから優先的に取得）
-    if ( isset( $ogp->_values['image'] ) && $ogp->_values['image'] ) {
-      $image = $ogp->_values['image'];
-    } elseif ( isset( $ogp->image ) && $ogp->image ) {
-      $image = $ogp->image;
-    }
+  if ( isset( $ogp->image ) && $ogp->image )
+    $image = $ogp->image;//画像URLの取得
 
     $error_rel_nofollow = null;
   }
@@ -237,9 +233,10 @@ function url_to_external_ogp_blogcard_tag($url){
   }
 
 
-  //og:imageが相対パスのとき	  //og:imageが相対パスのとき絶対URLに変換
-  if(!$image || (strpos($image, '//') === false) || (is_ssl() && (strpos($image, 'https:') === false))){    // //OGPのURL情報があるか	  if($image && (strpos($image, '//') === false)) {
-    //相対パスの時はエラー用の画像を
+  //og:imageが相対パスのとき
+  if(!$image || (strpos($image, '//') === false) || (is_ssl() && (strpos($image, 'https:') === false))){    // //OGPのURL情報があるか    //相対パスの時はエラー用の画像を表示
+    
+    //相対パスの時はエラー用の画像を表示
     $image = $error_image;
   }
   $title = strip_tags($title);

--- a/lib/blogcard-out.php
+++ b/lib/blogcard-out.php
@@ -187,7 +187,6 @@ function url_to_external_ogp_blogcard_tag($url){
           $ogp->image = $res;
         }
       }
-
       if ( isset( $ogp->title ) && $ogp->title )
         $title = $ogp->title;//タイトルの取得
 
@@ -213,8 +212,8 @@ function url_to_external_ogp_blogcard_tag($url){
     if ( isset( $ogp->description ) && $ogp->description )
       $snippet = $ogp->description;//ディスクリプションの取得
 
-  if ( isset( $ogp->image ) && $ogp->image )
-    $image = $ogp->image;//画像URLの取得
+    if ( isset( $ogp->image ) && $ogp->image )
+      $image = $ogp->image;//画像URLの取得
 
     $error_rel_nofollow = null;
   }
@@ -234,7 +233,7 @@ function url_to_external_ogp_blogcard_tag($url){
 
 
   //og:imageが相対パスのとき
-  if(!$image || (strpos($image, '//') === false) || (is_ssl() && (strpos($image, 'https:') === false))){    // //OGPのURL情報があるか    //相対パスの時はエラー用の画像を表示
+  if(!$image || (strpos($image, '//') === false) || (is_ssl() && (strpos($image, 'https:') === false))){    // //OGPのURL情報があるか
     
     //相対パスの時はエラー用の画像を表示
     $image = $error_image;

--- a/lib/blogcard-out.php
+++ b/lib/blogcard-out.php
@@ -183,7 +183,6 @@ function url_to_external_ogp_blogcard_tag($url){
         $res = fetch_card_image($ogp->image, $url);
 
         if ( $res ) {
-          // $ogp->_values['image'] = $res;
           $ogp->image = $res;
         }
       }
@@ -205,7 +204,6 @@ function url_to_external_ogp_blogcard_tag($url){
   } elseif ( $ogp == 'error' ) {
     //前回取得したとき404ページだったら何も出力しない
   } else {
-
     if ( isset( $ogp->title ) && $ogp->title )
       $title = $ogp->title;//タイトルの取得
 
@@ -230,7 +228,6 @@ function url_to_external_ogp_blogcard_tag($url){
   if ($domain_style === 'name' && !empty($ogp->site_name)) {
     $domain = $ogp->site_name; // OGPのサイト名を優先
   }
-
 
   //og:imageが相対パスのとき
   if(!$image || (strpos($image, '//') === false) || (is_ssl() && (strpos($image, 'https:') === false))){    // //OGPのURL情報があるか

--- a/lib/blogcard-out.php
+++ b/lib/blogcard-out.php
@@ -178,6 +178,7 @@ function url_to_external_ogp_blogcard_tag($url){
     if ( $ogp == false ) {
       $ogp = 'error';
     } else {
+
       if (isset($ogp->image) && !empty($ogp->image)) {
         //キャッシュ画像の取得
         $res = fetch_card_image($ogp->image, $url);
@@ -231,7 +232,6 @@ function url_to_external_ogp_blogcard_tag($url){
 
   //og:imageが相対パスのとき
   if(!$image || (strpos($image, '//') === false) || (is_ssl() && (strpos($image, 'https:') === false))){    // //OGPのURL情報があるか
-    
     //相対パスの時はエラー用の画像を表示
     $image = $error_image;
   }

--- a/lib/open-graph.php
+++ b/lib/open-graph.php
@@ -78,11 +78,12 @@ class OpenGraphGetter implements Iterator
         // _v($args);
         if (is_amazon_site_page($URI)) {
           $args['user-agent'] = 'Twitterbot/1.0';
-        }
-        if (is_rakuten_site_page($URI)) {
+        } elseif (is_rakuten_site_page($URI)) {
           //通常のユーザーエージェントだと楽天でOGP情報が取得できないため
           $args['user-agent'] = 'WordPress/'.get_bloginfo('version').'; '.get_the_site_domain();
         } else {
+          //その他のサイトでは標準的なブラウザのUser-Agentを使用（多くのサイトでOGP取得に有効）
+          $args['user-agent'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
           unset($args['headers']);
         }
 
@@ -187,7 +188,7 @@ class OpenGraphGetter implements Iterator
         }
 
         //Fallback to use image_src if ogp::image isn't set.
-        if (!isset($page->values['image'])) {
+        if (!isset($page->_values['image'])) {
             $domxpath = new DOMXPath($doc);
             $elements = $domxpath->query("//link[@rel='image_src']");
 

--- a/lib/open-graph.php
+++ b/lib/open-graph.php
@@ -78,12 +78,13 @@ class OpenGraphGetter implements Iterator
         // _v($args);
         if (is_amazon_site_page($URI)) {
           $args['user-agent'] = 'Twitterbot/1.0';
-        } elseif (is_rakuten_site_page($URI)) {
+        }
+        if (is_rakuten_site_page($URI)) {
           //通常のユーザーエージェントだと楽天でOGP情報が取得できないため
           $args['user-agent'] = 'WordPress/'.get_bloginfo('version').'; '.get_the_site_domain();
         } else {
           //その他のサイトでは標準的なブラウザのUser-Agentを使用（多くのサイトでOGP取得に有効）
-          $args['user-agent'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+          // $args['user-agent'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
           unset($args['headers']);
         }
 
@@ -188,7 +189,7 @@ class OpenGraphGetter implements Iterator
         }
 
         //Fallback to use image_src if ogp::image isn't set.
-        if (!isset($page->_values['image'])) {
+        if (!isset($page->values['image'])) {
             $domxpath = new DOMXPath($doc);
             $elements = $domxpath->query("//link[@rel='image_src']");
 

--- a/lib/open-graph.php
+++ b/lib/open-graph.php
@@ -83,8 +83,6 @@ class OpenGraphGetter implements Iterator
           //通常のユーザーエージェントだと楽天でOGP情報が取得できないため
           $args['user-agent'] = 'WordPress/'.get_bloginfo('version').'; '.get_the_site_domain();
         } else {
-          //その他のサイトでは標準的なブラウザのUser-Agentを使用（多くのサイトでOGP取得に有効）
-          // $args['user-agent'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
           unset($args['headers']);
         }
 


### PR DESCRIPTION
# 本PRの目的

外部ブログカードのサムネイルが表示されない不具合を修正できればと思います。

# 対応内容

- 「lib\blogcard-out.php」の182行目付近の条件分岐のemptyに「!」を追加し、fetch_card_image()関数をただしく処理されることにより、外部画像をローカルにダウンロード・保存しブログカードのサムネイル画像が表示されるように調整

# 対象フォーラム

[外部ブログカードのサムネイルが表示されない](https://wp-cocoon.com/community/bugs/%e5%a4%96%e9%83%a8%e3%83%96%e3%83%ad%e3%82%b0%e3%82%ab%e3%83%bc%e3%83%89%e3%81%ae%e3%82%b5%e3%83%a0%e3%83%8d%e3%82%a4%e3%83%ab%e3%81%8c%e8%a1%a8%e7%a4%ba%e3%81%95%e3%82%8c%e3%81%aa%e3%81%84/)

# 不具合イメージ

すべての外部ページがサムネイルの表示で不具合が起こるわけではなく、特定の場合に不具合が発生するイメージです。

![スクリーンショット 2025-10-08 163538](https://github.com/user-attachments/assets/69961442-6058-4184-8071-95509f17adfa)

■ 問題のURL

https://youglish.com/getbyid/108417770/call%20in%20loan/english

# 不具合の原因

今回問題だったファイルは「lib\blogcard-out.php」になりまして、結論としては182行目付近の条件分岐のemptyに「!」が無かったことによって不具合があったものと思われます。

前提として、今回はYouGlishによるエラーでしたが、YouGlishでは以下のような対策がなされていることと思われます。
- YouGlishは外部サイトからの画像直リンクを防ぐセキュリティ機能を実装
- Refererヘッダーで参照元をチェックし、外部からのアクセスを拒否

# 修正イメージ

lib\blogcard-out.phpにて、182行目付近のコードにて、今回対応前では以下のようになっておりました。

```
<?php
// 182行目付近 - 修正前の誤ったコード
if (isset($ogp->image) && empty($ogp->image)) {  // ❌ エラー（emptyに「!」が無い）
    //キャッシュ画像の取得
    $res = fetch_card_image($ogp->image, $url);
    
    if ( $res ) {
        $ogp->image = $res;
    }
}
```
そのため、以下のようにemptyに対して「!」を追加し、画像URLがある場合にfetch_card_image()関数が処理されるようにいたしました。

```
// 182行目付近 - 修正後の正しいコード
if (isset($ogp->image) && !empty($ogp->image)) {  // ✅ 条件を修正（emptyに「!」を追加）
    //キャッシュ画像の取得
    $res = fetch_card_image($ogp->image, $url);
    
    if ( $res ) {
        $ogp->image = $res;
    }
}
```

改めてまとめますと、以下のイメージになるかと思います。

- empty($ogp->image) ❌ → 「画像URLが空の場合に処理」→ 実際は画像があるので処理されない
- !empty($ogp->image) ✅ → 「画像URLがある場合に処理」→ 正しく処理される

この論理エラーにより、「外部画像キャッシュ機能」が全く動作せず、403 Forbiddenエラーが発生していたものと思われます。

# 修正後のイメージ

修正前では、以下のような処理の流れになっていたかと思います。

■ 修正前の処理の流れ

1. OpenGraphGetter::fetch( $url )により、例えば$ogp->image = "https://youglish.com/images/fb6.jpg"としてOGPが取得される
2. 182行目の`if (isset($ogp->image) && empty($ogp->image)) {`では、画像URLが取得できているためempty($ogp->image)がfalseとなる
3. 182行目の`if (isset($ogp->image) && empty($ogp->image)) {`にて、「true && false = false」となりfalseとなるため、fetch_card_image()がスキップされる
4. その結果、外部URLがそのまま残る
5. `<img src="https://youglish.com/images/fb6.jpg">`の形でHTML出力される
6. ブラウザは、外部サイトに直接アクセスすることになる
7. YouGlishサーバーが403 Forbiddenのエラーを返す

今回の修正で、以下のような処理の流れになったかと思います。

■ 修正後の処理の流れ

1.  OpenGraphGetter::fetch( $url )により、例えば$ogp->image = "https://youglish.com/images/fb6.jpg"としてOGPが取得される
2. 182行目の`if (isset($ogp->image) && !empty($ogp->image)) {`では、画像URLが取得できているため!empty($ogp->image)がtrueとなる
3. 182行目の`if (isset($ogp->image) && !empty($ogp->image)) {`にて、「true && true = true」となりtrueとなるため、fetch_card_image()がちゃんと実行される
4. Cocoonの処理により外部画像をローカルにダウンロード・保存される
5. fetch_card_image()関数により、$ogp->image = "https://ドメイン/wp-content/uploads/..."の形でURLが置換される
6.  `<img src=""https://ドメイン/wp-content/uploads/...">`の形でHTML出力される
7. ブラウザは、自サイトの画像にアクセスされることになる
9. 正常に画像が表示される

これにより、下図のように無事画像が表示されるように修正できたかと思います。

![スクリーンショット 2025-10-08 163921](https://github.com/user-attachments/assets/72559f14-4a15-4ab5-b8ef-fb723030bfb3)