### PR TITLE
人気記事の表示順を、PV数が同一の場合に日付順で表示させる形でクエリを調整

### DIFF
--- a/lib/page-access/access-func.php
+++ b/lib/page-access/access-func.php
@@ -351,7 +351,7 @@ function wrap_joined_wp_posts_query($query, $limit, $author, $post_type, $snippe
     WHERE post_status = 'publish' AND
           post_type = '{$post_type}'".
           $author_query."
-    ORDER BY sum_count DESC, post_id
+    ORDER BY sum_count DESC, post_date DESC
     LIMIT $limit
   ";
   //_v($query);
@@ -465,7 +465,7 @@ function get_access_ranking_records($days = 'all', $limit = 5, $type = ET_DEFAUL
         ) AS {$joined_table} #カテゴリーとアクセステーブルを内部結合した仮の名前
 
         GROUP BY {$joined_table}.post_id
-        ORDER BY sum_count DESC, post_id
+        ORDER BY sum_count DESC, {$joined_table}.post_id
     ";
     //_v($query);
     //1回のクエリで投稿データを取り出せるようにテーブル結合クエリを追加
@@ -475,7 +475,7 @@ function get_access_ranking_records($days = 'all', $limit = 5, $type = ET_DEFAUL
       SELECT {$access_table}.post_id, SUM({$access_table}.count) AS sum_count
         FROM {$access_table} $where
         GROUP BY {$access_table}.post_id
-        ORDER BY sum_count DESC, post_id
+        ORDER BY sum_count DESC, {$access_table}.post_id
     ";
     //1回のクエリで投稿データを取り出せるようにテーブル結合クエリを追加
     $query = wrap_joined_wp_posts_query($query, $limit, $author, $post_type, $snippet);

--- a/lib/page-access/access-func.php
+++ b/lib/page-access/access-func.php
@@ -330,7 +330,7 @@ function get_all_access_count($post_id = null){
 endif;
 
 if ( !function_exists( 'wrap_joined_wp_posts_query' ) ):
-function wrap_joined_wp_posts_query($query, $limit, $author, $post_type, $snippet = 0, $secondary_sort = 'post_date DESC'){
+function wrap_joined_wp_posts_query($query, $limit, $author, $post_type, $snippet = 0){
   global $wpdb;
   $wp_posts = $wpdb->posts;
   $ranks_posts = 'ranks_posts';
@@ -351,7 +351,7 @@ function wrap_joined_wp_posts_query($query, $limit, $author, $post_type, $snippe
     WHERE post_status = 'publish' AND
           post_type = '{$post_type}'".
           $author_query."
-    ORDER BY sum_count DESC, {$secondary_sort}
+    ORDER BY sum_count DESC, post_date DESC
     LIMIT $limit
   ";
   //_v($query);

--- a/lib/page-access/access-func.php
+++ b/lib/page-access/access-func.php
@@ -470,7 +470,6 @@ function get_access_ranking_records($days = 'all', $limit = 5, $type = ET_DEFAUL
     //_v($query);
     //1回のクエリで投稿データを取り出せるようにテーブル結合クエリを追加
     $query = wrap_joined_wp_posts_query($query, $limit, $author, $post_type, $snippet);
-
   } else {
     $query = "
       SELECT {$access_table}.post_id, SUM({$access_table}.count) AS sum_count


### PR DESCRIPTION
# 本PRの目的

人気記事の表示順を、PV数が同一の場合に日付順で表示させる形でクエリを調整できればと思います。

# 対象フォーラム

[人気記事の表示順について](https://wp-cocoon.com/community/cocoon-theme/%e4%ba%ba%e6%b0%97%e8%a8%98%e4%ba%8b%e3%81%ae%e8%a1%a8%e7%a4%ba%e9%a0%86%e3%81%ab%e3%81%a4%e3%81%84%e3%81%a6/)

# 対応内容

- lib\page-access\access-func.phpのwrap_joined_wp_posts_query()関数のSQLクエリ文の並び替え指定の「ORDER BY」の「post_id」を「post_date DESC」へ調整

# 調整前イメージ

前提として、下図のように4件の投稿ページが古い順にA～Dのページが公開されているものとします。

![スクリーンショット 2025-10-27 174415](https://github.com/user-attachments/assets/df7500d7-6c51-4181-bc1e-441fe2735b64)

そして、人気記事のウィジェット・ブロック・ショートコードを設定して表示を確認すると、下図のようにID順（昇順）で一覧の並びが決まっているのが確認できます。

■ 人気記事ウィジェット

![スクリーンショット 2025-10-27 174540](https://github.com/user-attachments/assets/1cbc02c4-b85e-4398-b866-299c25135a27)

■ 人気記事ブロック・人気記事ショートコード

![スクリーンショット 2025-10-27 174656](https://github.com/user-attachments/assets/f86cfd5f-ab5c-4d1d-8d5c-50d54d1d8251)

# 調整後イメージ

当PRにて調整後は、下図のように投稿日順（降順）で表示され、一覧としてわかりやすくなったかと思います。

以下の例では、同じ2カウント同士、1カウント同士の順番が日付順になっている例となります。

■ 人気記事ウィジェット

![スクリーンショット 2025-10-27 175112](https://github.com/user-attachments/assets/480af3d0-8686-4070-976c-296518684442)

■ 人気記事ブロック・人気記事ショートコード

![スクリーンショット 2025-10-27 175021](https://github.com/user-attachments/assets/18a1dd04-4dd8-4476-8d15-ec225fb53850)

# 調整内容

調整内容として、lib\page-access\access-func.phpのwrap_joined_wp_posts_query()関数のSQLクエリ文の並び替え指定の「ORDER BY」の「post_id」を「post_date DESC」へ調整いたしました。

https://github.com/xserver-inc/cocoon/pull/302/files#diff-e605148376532b6e7c55af310b3b7441dc958cf59ff6046bfd1498c7882a8984L354

wrap_joined_wp_posts_query()関数は、「別の場所で処理した集計結果（元のクエリ）」と「記事の基本情報（タイトルや日付など）」のそれぞれのテーブルを合体させ、最終的なランキングリストを作るためのSQLクエリを組み立てるラップ関数になるかと思います。

今回の修正により、アクセスランキングデータを取得・管理する関数であるget_access_ranking_records()関数にて、wrap_joined_wp_posts_query()関数を使って最終的なランキングリストのテーブルを作成する処理となっているかと思いますが、元のラップ関数であるwrap_joined_wp_posts_query()関数のSQLを調整することにより、少ないコードでシンプルな構成で調整可能かと思い今回の形で調整を行いました。

# 補足・メモ

get_access_ranking_records()関数内の468、478行目付近の2か所の「ORDER BY sum_count DESC, post_id」に関しては調整は必要ない認識です。
理由としては、先にサブクエリとして集計したテーブルを作成しておき、あとからラップ関数であるwrap_joined_wp_posts_query()関数にて並び替えが可能だからです。

また、そもそもget_access_ranking_records()関数の処理の段階では、wp_postsテーブルと結合していないため、post_dateが利用できないため、調整不要の認識です。

## get_access_ranking_records()関数が利用されている箇所・影響範囲

lib\html-forms.php
lib\hook-wp.php
tmp\carousel.php