### PR TITLE
ブロックパターン一覧画面のカラムにて、ブロックパターンに「PV表示」「アイキャッチ表示」「メモ表示」は必要ないため表示しない処理を追加

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -110,6 +110,9 @@ add_filter( 'manage_posts_columns', 'customize_admin_manage_posts_columns' );
 add_filter( 'manage_pages_columns', 'customize_admin_manage_posts_columns' );
 if ( !function_exists( 'customize_admin_manage_posts_columns' ) ):
 function customize_admin_manage_posts_columns($columns) {
+  //現在のスクリーン情報を取得
+  $screen = get_current_screen();
+
   //作成者表示
   if (!is_admin_list_author_visible()) {
     unset($columns['author']);
@@ -145,18 +148,18 @@ function customize_admin_manage_posts_columns($columns) {
     $columns['word-count'] = __( '文字数', THEME_NAME );
   }
 
-  //文字数表示
-  if (is_admin_list_pv_visible()) {
+  //PV表示
+  if (is_admin_list_pv_visible() && ($screen && $screen->id !== 'edit-wp_block')) {
     $columns['pv'] = __( 'PV', THEME_NAME );
   }
 
   //アイキャッチ表示
-  if (is_admin_list_eyecatch_visible()) {
+  if (is_admin_list_eyecatch_visible() && ($screen && $screen->id !== 'edit-wp_block')) {
     $columns['thumbnail'] = __( 'アイキャッチ', THEME_NAME );
   }
 
   //メモ表示
-  if (is_admin_list_memo_visible()) {
+  if (is_admin_list_memo_visible() && ($screen && $screen->id !== 'edit-wp_block')) {
     $columns['memo'] = __( 'メモ', THEME_NAME );
   }
 

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -110,8 +110,8 @@ add_filter( 'manage_posts_columns', 'customize_admin_manage_posts_columns' );
 add_filter( 'manage_pages_columns', 'customize_admin_manage_posts_columns' );
 if ( !function_exists( 'customize_admin_manage_posts_columns' ) ):
 function customize_admin_manage_posts_columns($columns) {
-  //現在のスクリーン情報を取得
-  $screen = get_current_screen();
+  // 現在の画面オブジェクトを取得
+  $current_screen = get_current_screen();
 
   //作成者表示
   if (!is_admin_list_author_visible()) {
@@ -149,17 +149,17 @@ function customize_admin_manage_posts_columns($columns) {
   }
 
   //PV表示
-  if (is_admin_list_pv_visible() && ($screen && $screen->id !== 'edit-wp_block')) {
+  if (is_admin_list_pv_visible() && ($current_screen && $current_screen->id !== 'edit-wp_block')) {
     $columns['pv'] = __( 'PV', THEME_NAME );
   }
 
   //アイキャッチ表示
-  if (is_admin_list_eyecatch_visible() && ($screen && $screen->id !== 'edit-wp_block')) {
+  if (is_admin_list_eyecatch_visible() && ($current_screen && $current_screen->id !== 'edit-wp_block')) {
     $columns['thumbnail'] = __( 'アイキャッチ', THEME_NAME );
   }
 
   //メモ表示
-  if (is_admin_list_memo_visible() && ($screen && $screen->id !== 'edit-wp_block')) {
+  if (is_admin_list_memo_visible() && ($current_screen && $current_screen->id !== 'edit-wp_block')) {
     $columns['memo'] = __( 'メモ', THEME_NAME );
   }
 


### PR DESCRIPTION
# 本PRの目的

旧ブロックパターン一覧画面のカラムにて、ブロックパターンに「PV表示」「アイキャッチ表示」「メモ表示」の機能は存在しないため、カラムに表示しない処理を追加できればと思います。

→ブロックパターンに無い機能の項目が表示されなくなるため、ユーザーの混乱の防止につながるかと思います。

# 対象フォーラム

[パターン一覧のカラム表示について](https://wp-cocoon.com/community/cocoon-theme/%e3%83%91%e3%82%bf%e3%83%bc%e3%83%b3%e4%b8%80%e8%a6%a7%e3%81%ae%e3%82%ab%e3%83%a9%e3%83%a0%e8%a1%a8%e7%a4%ba%e3%81%ab%e3%81%a4%e3%81%84%e3%81%a6/#post-86734)

# 対応内容

- lib/admin.phpのcustomize_admin_manage_posts_columns()関数での一覧管理画面のカラム項目表示処理において、ブロックパターン画面の時に「PV表示」「アイキャッチ表示」「メモ表示」を非表示になるように条件分岐処理を調整
- コメントアウトを「文字数表示」から「PV表示」へ調整

# 正前イメージ

まず「Cocoon設定」の「管理者設定」→「カラム表示」の項目を設定します。

![スクリーンショット 2025-10-16 153245](https://github.com/user-attachments/assets/fc65c0ae-3b1a-418e-b478-f62ba4f8e780)

ブロックパターン一覧画面（古い方）の確認方法として、画面上の管理バーにある「管理メニュー」の「パターン一覧」をクリックして表示します。

![スクリーンショット 2025-10-16 151737](https://github.com/user-attachments/assets/ce8a279f-c958-42cb-a1fe-27c8b6032131)

ブロックパターン一覧画面が表示され、修正前ではブロックパターンに機能として存在しない「PV表示」「アイキャッチ表示」「メモ表示」の3つのカラム項目が表示できるようになっております。

![スクリーンショット 2025-10-16 151507](https://github.com/user-attachments/assets/6de3e20e-d9e2-4f16-ab91-cf73205fe0f6)

# 修正後イメージ

修正後は、下図のように「PV表示」「アイキャッチ表示」「メモ表示」が非表示になり表示がすっきりした状態になります。
本来使用できない項目が無くなったため、ユーザーも混乱しません。

<img width="804" height="393" alt="スクリーンショット 2025-10-16 151202" src="https://github.com/user-attachments/assets/195e95d5-cc1e-4876-a313-96b90a2f791b" />

画面上の「表示オプション」からも非表示になっていることと思います。

<img width="718" height="151" alt="スクリーンショット 2025-10-16 151226" src="https://github.com/user-attachments/assets/7b0a4274-acee-4879-acc2-1feede101014" />