### PR TITLE
投稿一覧管理画面のカラムの調整対応の件で、条件分岐の変数を削除し不具合を修正

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -149,17 +149,17 @@ function customize_admin_manage_posts_columns($columns) {
   }
 
   //PV表示
-  if (is_admin_list_pv_visible() && ($current_screen && $current_screen->id !== 'edit-wp_block')) {
+  if (is_admin_list_pv_visible() && ($current_screen->id !== 'edit-wp_block')) {
     $columns['pv'] = __( 'PV', THEME_NAME );
   }
 
   //アイキャッチ表示
-  if (is_admin_list_eyecatch_visible() && ($current_screen && $current_screen->id !== 'edit-wp_block')) {
+  if (is_admin_list_eyecatch_visible() && ($current_screen->id !== 'edit-wp_block')) {
     $columns['thumbnail'] = __( 'アイキャッチ', THEME_NAME );
   }
 
   //メモ表示
-  if (is_admin_list_memo_visible() && ($current_screen && $current_screen->id !== 'edit-wp_block')) {
+  if (is_admin_list_memo_visible() && ($current_screen->id !== 'edit-wp_block')) {
     $columns['memo'] = __( 'メモ', THEME_NAME );
   }
 

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -149,17 +149,17 @@ function customize_admin_manage_posts_columns($columns) {
   }
 
   //PV表示
-  if (is_admin_list_pv_visible() && ($current_screen->id !== 'edit-wp_block')) {
+  if (is_admin_list_pv_visible() && (!$current_screen || $current_screen->id !== 'edit-wp_block')) {
     $columns['pv'] = __( 'PV', THEME_NAME );
   }
 
   //アイキャッチ表示
-  if (is_admin_list_eyecatch_visible() && ($current_screen->id !== 'edit-wp_block')) {
+  if (is_admin_list_eyecatch_visible() && (!$current_screen || $current_screen->id !== 'edit-wp_block')) {
     $columns['thumbnail'] = __( 'アイキャッチ', THEME_NAME );
   }
 
   //メモ表示
-  if (is_admin_list_memo_visible() && ($current_screen->id !== 'edit-wp_block')) {
+  if (is_admin_list_memo_visible() && (!$current_screen || $current_screen->id !== 'edit-wp_block')) {
     $columns['memo'] = __( 'メモ', THEME_NAME );
   }
 


### PR DESCRIPTION
# 本PRの目的

先日[こちら](https://github.com/xserver-inc/cocoon/pull/303)で行いました不具合対応にて、不具合がありましたため調整できればと思います。

# 修正元PR

https://github.com/xserver-inc/cocoon/pull/303

# 対応内容

- 投稿一覧管理画面にてクイック編集時に一部項目が消えてしまう不具合があるため、lib\admin.phpの条件分岐を調整

# 不具合内容

先日パターン一覧の管理画面にて「PV表示」「アイキャッチ表示」「メモ表示」は必要ないため表示しない処理を追加しましたが、別の箇所で不具合が起こりました。

内容としては、以下のようにページ一覧系の管理画面でクイック編集を保存したときに、下図のように表示に崩れが起こってしまう現象です。

![スクリーンショット 2025-10-19 145848](https://github.com/user-attachments/assets/90b31e56-a105-437e-aaf0-6a6c4f5f642c)

# 対象フォーラム

https://wp-cocoon.com/community/cocoon-theme/%e3%83%91%e3%82%bf%e3%83%bc%e3%83%b3%e4%b8%80%e8%a6%a7%e3%81%ae%e3%82%ab%e3%83%a9%e3%83%a0%e8%a1%a8%e7%a4%ba%e3%81%ab%e3%81%a4%e3%81%84%e3%81%a6

# 動作確認

- パターン一覧にて正常に「PV表示」「アイキャッチ表示」「メモ表示」が非表示になっていることを確認
- 投稿・固定ページ・カスタム投稿タイプでのクイック編集時に正常に動くことを確認
- 他すべての管理画面を確認
- クイック編集にて複数パターンで挙動を確認（投稿ステータスを変えて保存等）
- 投稿一覧での「表示モード」で「コンパクト表示」「拡張表示」どちらでも問題なし
- カラムの表示数や表示内容によって挙動がおかしくならないことも確認
- $current_screen->id !== 'edit-wp_block'のみの条件分岐だと、クイック編集時に以下のエラーが起こってしまうため、「!$current_screen || 」加える条件分岐としました。

```
[22-Oct-2025 05:53:52 UTC] PHP Warning:  Attempt to read property "id" on null in /var/www/html/wp-content/themes/cocoon-master/lib/admin.php on line 152
[22-Oct-2025 05:53:52 UTC] PHP Warning:  Attempt to read property "id" on null in /var/www/html/wp-content/themes/cocoon-master/lib/admin.php on line 157
[22-Oct-2025 05:53:52 UTC] PHP Warning:  Attempt to read property "id" on null in /var/www/html/wp-content/themes/cocoon-master/lib/admin.php on line 162
```

# 補足

調整途中で、以下のように条件分岐を調整しましたが...

```
  //PV表示
  if (is_admin_list_pv_visible() && ($current_screen->id !== 'edit-wp_block')) {
    $columns['pv'] = __( 'PV', THEME_NAME );
  }

  //アイキャッチ表示
  if (is_admin_list_eyecatch_visible() && ($current_screen->id !== 'edit-wp_block')) {
    $columns['thumbnail'] = __( 'アイキャッチ', THEME_NAME );
  }

  //メモ表示
  if (is_admin_list_memo_visible() && ($current_screen->id !== 'edit-wp_block')) {
    $columns['memo'] = __( 'メモ', THEME_NAME );
  }
```

以下のように Warningエラーがみられたため...

```
[22-Oct-2025 05:53:52 UTC] PHP Warning:  Attempt to read property "id" on null in /var/www/html/wp-content/themes/cocoon-master/lib/admin.php on line 152
[22-Oct-2025 05:53:52 UTC] PHP Warning:  Attempt to read property "id" on null in /var/www/html/wp-content/themes/cocoon-master/lib/admin.php on line 157
[22-Oct-2025 05:53:52 UTC] PHP Warning:  Attempt to read property "id" on null in /var/www/html/wp-content/themes/cocoon-master/lib/admin.php on line 162
```

以下のように条件分岐を調整いたしました。

```
  //PV表示
  if (is_admin_list_pv_visible() && (!$current_screen || $current_screen->id !== 'edit-wp_block')) {
    $columns['pv'] = __( 'PV', THEME_NAME );
  }

  //アイキャッチ表示
  if (is_admin_list_eyecatch_visible() && (!$current_screen || $current_screen->id !== 'edit-wp_block')) {
    $columns['thumbnail'] = __( 'アイキャッチ', THEME_NAME );
  }

  //メモ表示
  if (is_admin_list_memo_visible() && (!$current_screen || $current_screen->id !== 'edit-wp_block')) {
    $columns['memo'] = __( 'メモ', THEME_NAME );
  }
```

https://github.com/xserver-inc/cocoon/pull/304/files

「!$current_screen || 」のように条件分岐することによって、$current_screenがnullでもエラーが発生せずPHPエラーの防止になり、wp_block一覧でのみ項目を非表示にできるようになります。