### PR TITLE
OpenGraphGetterクラスでの動的プロパティの非推奨エラーを解消

### DIFF
--- a/lib/blogcard-out.php
+++ b/lib/blogcard-out.php
@@ -178,13 +178,13 @@ function url_to_external_ogp_blogcard_tag($url){
     if ( $ogp == false ) {
       $ogp = 'error';
     } else {
-
-      if (isset($ogp->image) && !empty($ogp->image)) {
-        //キャッシュ画像の取得
+      // og:image が存在する場合、必ずキャッシュ画像を参照
+      if ( isset($ogp->image) && $ogp->image ) {
         $res = fetch_card_image($ogp->image, $url);
-
-        if ( $res ) {
-          $ogp->image = $res;
+        if ($res) {
+          $image = $res; // キャッシュ画像をセット
+        } else {
+          $image = $ogp->image; // キャッシュが作れなければ元の og:image
         }
       }
 
@@ -193,9 +193,6 @@ function url_to_external_ogp_blogcard_tag($url){
 
       if ( isset( $ogp->description ) && $ogp->description )
         $snippet = $ogp->description;//ディスクリプションの取得
-
-      if ( isset( $ogp->image ) && $ogp->image )
-        $image = $ogp->image;////画像URLの取得
 
       $error_rel_nofollow = null;
     }
@@ -212,8 +209,15 @@ function url_to_external_ogp_blogcard_tag($url){
     if ( isset( $ogp->description ) && $ogp->description )
       $snippet = $ogp->description;//ディスクリプションの取得
 
-    if ( isset( $ogp->image ) && $ogp->image )
-      $image = $ogp->image;//画像URLの取得
+    // og:image が存在する場合、必ずキャッシュ画像を参照
+    if ( isset($ogp->image) && $ogp->image ) {
+      $res = fetch_card_image($ogp->image, $url);
+      if ($res) {
+        $image = $res; // キャッシュ画像をセット
+      } else {
+        $image = $ogp->image; // キャッシュが作れなければ元の og:image
+      }
+    }
 
     $error_rel_nofollow = null;
   }

--- a/lib/open-graph.php
+++ b/lib/open-graph.php
@@ -26,7 +26,6 @@
  */
 if ( !defined( 'ABSPATH' ) ) exit;
 
-#[AllowDynamicProperties]
 class OpenGraphGetter implements Iterator
 {
   /**

--- a/lib/open-graph.php
+++ b/lib/open-graph.php
@@ -26,6 +26,7 @@
  */
 if ( !defined( 'ABSPATH' ) ) exit;
 
+#[AllowDynamicProperties]
 class OpenGraphGetter implements Iterator
 {
   /**


### PR DESCRIPTION
# 本PRの目的

[こちらのPR](https://github.com/xserver-inc/cocoon/pull/301)の対応によって、以下のエラーが発生したため解決できればと思います。

`Deprecated: Creation of dynamic property OpenGraphGetter::$image is deprecated in /virtual/chuya/public_html/temp/wp-content/themes/cocoon-master/lib/blogcard-out.php on line 187`

# 修正元PR

https://github.com/xserver-inc/cocoon/pull/301

# 対象フォーラム

https://wp-cocoon.com/community/bugs/%e5%a4%96%e9%83%a8%e3%83%96%e3%83%ad%e3%82%b0%e3%82%ab%e3%83%bc%e3%83%89%e3%81%ae%e3%82%b5%e3%83%a0%e3%83%8d%e3%82%a4%e3%83%ab%e3%81%8c%e8%a1%a8%e7%a4%ba%e3%81%95%e3%82%8c%e3%81%aa%e3%81%84/

# 対応内容

- lib\open-graph.phpのOpenGraphGetterクラスによって発生していたPHP8.2での仕様変更による動的プロパティの非推奨エラー対策として、lib/blogcard-out.phpのurl_to_external_ogp_blogcard_tag()関数内の処理の代入方法を調整

# 不具合再現方法

投稿ページ等を新規作成して、エディタへブログカード作成のためにURLを追加していただき、Cocoon設定サブメニューにあるキャッシュを削除をしてからページを確認すると非推奨のエラーが確認できます。

![スクリーンショット 2025-10-23 134018](https://github.com/user-attachments/assets/a41566d8-d8e3-41f0-94fd-9802a7c69a83)
※確認ツールとしては、WordPressプラグインの「Query Monitor」を利用しております。

# 不具合の原因

PHP8.2での仕様変更により、動的プロパティは非推奨となったのが原因かと思われます。
https://www.php.net/manual/ja/migration82.deprecated.php

高澤が先日のPRで完了したコードとして、function url_to_external_ogp_blogcard_tag()関数内の187行目付近の以下の箇所で、以下のように記述しておりました。

`$ogp->image = $res;`

https://github.com/xserver-inc/cocoon/pull/306/files#diff-8add289d444feefcab60296de20d3db7f99d704dbb58e8f2cb74fcb53d56aa34L187

上記の処理により、OpenGraphGetterクラスにて事前に宣言されていないimageプロパティに代入することにより、インスタンス独自に動的なプロパティが作成されることとなり、非推奨のエラーが発生した流れになったかと思われます。

# 対応策

普通のローカル変数「$image」へ代入することにより、解決することといたしました。
$imageは関数内のローカル変数で、クラスのプロパティではなく、動的プロパティの作成が発生しないため、問題を解決できたかと思います。

https://github.com/xserver-inc/cocoon/pull/306/files#diff-8add289d444feefcab60296de20d3db7f99d704dbb58e8f2cb74fcb53d56aa34R181

https://github.com/xserver-inc/cocoon/pull/306/files#diff-8add289d444feefcab60296de20d3db7f99d704dbb58e8f2cb74fcb53d56aa34R181

上記コードはchu-yaさんからご提供いただいたものを参考にさせていただき、確認した上で反映させていただきました。ありがとうございました。