### PR TITLE
Cocoon設定[インデックス]の表示カテゴリーで空のカテゴリーも正しく表示して選択可能となるように調整

### DIFF
--- a/lib/html-forms.php
+++ b/lib/html-forms.php
@@ -747,7 +747,7 @@ function hierarchical_category_check_list( $cat, $name, $checks ) {
   }
     // wpse-41548 // alchymyth // a hierarchical list of all categories //
 
-  $next = get_categories('hide_empty=false&orderby=name&order=ASC&parent=' . $cat);
+  $next = get_categories('hide_empty=0&orderby=name&order=ASC&parent=' . $cat);
 
   if( $next ) {
     foreach( $next as $cat ) :


### PR DESCRIPTION
# 本PRの目的

Cocoon設定[インデックス]の表示カテゴリーで空のカテゴリーも正しく表示して選択可能となるように調整できればと思います。

# 対象フォーラム

[[インデックス]の表示カテゴリーについて](https://wp-cocoon.com/community/cocoon-theme/%E3%82%A4%E3%83%B3%E3%83%87%E3%83%83%E3%82%AF%E3%82%B9%E3%81%AE%E8%A1%A8%E7%A4%BA%E3%82%AB%E3%83%86%E3%82%B4%E3%83%AA%E3%83%BC%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6/)

# 対応内容

- lib/html-forms.phpの750行目のget_categories()関数の引数である「hide_empty=false」での値を「false」から「0」へ調整

# 不具合の原因

lib/html-forms.phpの750行目のget_categories()関数の引数である「hide_empty=false」での値を「false」としているのが原因でした。

[lib/html-forms.php](https://github.com/xserver-inc/cocoon/pull/307/files#diff-4eb8121b22431a8363010400ce47d366bcc0798a9553a077b2ad05179d12e86eL750)

WordPressコアの仕様で「文字列形式」と「配列形式」でfalseの扱いが違うようでした。

# 不具合対応内容

これまでは以下のようにコードを記述しておりましたが...

`'hide_empty=false&orderby=name&order=ASC&parent=' . $cat`

今回の調整によって、以下のように「hide_empty=0」のように調整し、ただしい挙動となるようにいたしました。

`'hide_empty=0&orderby=name&order=ASC&parent=' . $cat`

# 不具合のご確認方法

念のため修正前の問題と思われる挙動を、不具合再現手順という意味も含めてメモさせていただきます。

1. カテゴリーAを作成
2. カテゴリーAを投稿ページBを作成して紐づけして「公開」
3. Cocoon設定の「インデックス」の「表示カテゴリー」にてカテゴリーAが項目として表示され選択可能になる
4. カテゴリーAをチェックして選択
5. 「表示形式」にて「一覧（デフォルト）」以外を選択
6. フロント上ただしく表示される
7. このタイミングで投稿ページBを非公開にする
8. フロント上カテゴリーAで「NOT FOUND」となる
9. フロント上のカテゴリーAの表示を非表示にしたい
10. 【★問題点】Cocoon設定の「インデックス」の「表示カテゴリー」にてカテゴリーAが項目として消えてしまっているため、カテゴリーAを削除できない
11. 投稿ページBを一旦また非公開から公開に戻す
12. Cocoon設定の「インデックス」の「表示カテゴリー」にてカテゴリーAが項目として選択可能となる
13. チェックを外して設定を保存
14. ここでやっとフロント上でカテゴリーAを非表示にできる

↑上記フロント表示上でチェックしたカテゴリー表示を非表示にするのに、再度記事ページを公開してからチェックボックスをはずして操作しなければならなくなっておりました。

また、既存のコード的に「投稿が1件もない空のカテゴリーも含めて表示」が正しいものと思われます。
`'hide_empty=false&orderby=name&order=ASC&parent=' . $cat`

# 修正後イメージ

まず下図のようにカテゴリーの紐づけ0件（空のカテゴリー）があるとして...

![スクリーンショット 2025-10-24 192244](https://github.com/user-attachments/assets/e77f584b-60f3-4f06-ba9a-4dcb641f02c2)

修正前は下図のように空のカテゴリーは表示されておりませんでしたが...

<img width="787" height="392" alt="image" src="https://github.com/user-attachments/assets/e0f4bbe3-91eb-4d8c-b1fe-0258d3f7df19" />

修正後はちゃんと下図のように空のカテゴリーも選択可能とすることといたしました。

![スクリーンショット 2025-10-24 192751](https://github.com/user-attachments/assets/54ef3410-4114-4874-aa10-ae0ad8ff56ea)

# 補足

同じくCocoon設定「インデックス」の「除外カテゴリー」も空のカテゴリーが表示されてちゃんと機能するようになっております。

![スクリーンショット 2025-10-24 193401](https://github.com/user-attachments/assets/72395745-9c79-43d9-8f4e-6e33c8128505)