### PR TITLE
ウィジェットのページ表示チェックリストのコードをリファクタリング

### DIFF
--- a/lib/html-forms.php
+++ b/lib/html-forms.php
@@ -793,96 +793,49 @@ endif;
 //ページ表示チェックリスト
 if ( !function_exists( 'generate_page_display_check_list' ) ):
 function generate_page_display_check_list( $name, $checks, $width = 0 ) {
-  if ($width == 0) {
-    $width = 'auto';
-  } else {
-    $width = $width.'px';
+  $width = ($width == 0) ? 'auto' : $width . 'px';
+  $checks = (array) $checks;
+
+  // 基本のチェック項目
+  $page_types = array(
+    'is_front_page'  => __( 'フロントページのみ', THEME_NAME ),
+    'is_single'      => __( '投稿', THEME_NAME ),
+    'is_page'        => __( '固定ページ', THEME_NAME ),
+    'is_category'    => __( 'カテゴリー一覧', THEME_NAME ),
+    'is_tag'         => __( 'タグ一覧', THEME_NAME ),
+    'is_author'      => __( '著者一覧', THEME_NAME ),
+    'is_archive'     => __( 'アーカイブ一覧', THEME_NAME ),
+    'is_search'      => __( '検索結果一覧', THEME_NAME ),
+    'is_404'         => __( '404ページ', THEME_NAME ),
+  );
+
+  // 条件付きのチェック項目を動的に追加
+  if ( function_exists('is_amp_enable') && is_amp_enable() ) {
+    $page_types['is_amp'] = __( 'AMPページ', THEME_NAME );
+  }
+  if ( function_exists('is_wpforo_exist') && is_wpforo_exist() ) {
+    $page_types['is_wpforo_plugin_page'] = __( 'wpForoページ', THEME_NAME );
+  }
+  if ( function_exists('is_bbpress_exist') && is_bbpress_exist() ) {
+    $page_types['is_bbpress_page'] = __( 'bbPressページ', THEME_NAME );
+  }
+  if ( function_exists('is_buddypress_exist') && is_buddypress_exist() ) {
+    $page_types['is_buddypress_page'] = __( 'BuddyPressページ', THEME_NAME );
+  }
+  if ( function_exists('is_plugin_fourm_exist') && is_plugin_fourm_exist() ) {
+    $page_types['is_plugin_fourm_page'] = __( 'プラグインフォーラムページ（bbPress、BuddyPress、wpForo）', THEME_NAME );
   }
 
-  if (empty($checks)) {
-    $checks = array();
-  }
+  echo '<div class="tab-content page-display-check-list ' . esc_attr($name) . '-list" style="width:' . esc_attr($width) . ';">';
+  echo '<ul>';
 
-  echo '<div class="tab-content page-display-check-list '.$name.'-list" style="width: '.$width.';"><ul>';
-
-  $id = $name.'_'.'is_front_page';
-  echo '<li><input type="checkbox" name="'.$name.'[]" value="is_front_page" id="'.$id.'" ';
-  checked(in_array('is_front_page', $checks));
-  echo '><label for="'.$id.'">' . __( 'フロントページのみ', THEME_NAME ) . '</label></li>';
-
-  $id = $name.'_'.'is_single';
-  echo '<li><input type="checkbox" name="'.$name.'[]" value="is_single" id="'.$id.'" ';
-  checked(in_array('is_single', $checks));
-  echo '><label for="'.$id.'">' . __( '投稿', THEME_NAME ) . '</label></li>';
-
-  $id = $name.'_'.'is_page';
-  echo '<li><input type="checkbox" name="'.$name.'[]" value="is_page" id="'.$id.'" ';
-  checked(in_array('is_page', $checks));
-  echo '><label for="'.$id.'">' . __( '固定ページ', THEME_NAME ) . '</label></li>';
-
-  $id = $name.'_'.'is_category';
-  echo '<li><input type="checkbox" name="'.$name.'[]" value="is_category" id="'.$id.'" ';
-  checked(in_array('is_category', $checks));
-  echo '><label for="'.$id.'">' . __( 'カテゴリー一覧', THEME_NAME ) . '</label></li>';
-
-  $id = $name.'_'.'is_tag';
-  echo '<li><input type="checkbox" name="'.$name.'[]" value="is_tag" id="'.$id.'" ';
-  checked(in_array('is_tag', $checks));
-  echo '><label for="'.$id.'">' . __( 'タグ一覧', THEME_NAME ) . '</label></li>';
-
-  $id = $name.'_'.'is_author';
-  echo '<li><input type="checkbox" name="'.$name.'[]" value="is_author" id="'.$id.'" ';
-  checked(in_array('is_author', $checks));
-  echo '><label for="'.$id.'">' . __( '著者一覧', THEME_NAME ) . '</label></li>';
-
-  $id = $name.'_'.'is_archive';
-  echo '<li><input type="checkbox" name="'.$name.'[]" value="is_archive" id="'.$id.'" ';
-  checked(in_array('is_archive', $checks));
-  echo '><label for="'.$id.'">' . __( 'アーカイブ一覧', THEME_NAME ) . '</label></li>';
-
-  $id = $name.'_'.'is_search';
-  echo '<li><input type="checkbox" name="'.$name.'[]" value="is_search" id="'.$id.'" ';
-  checked(in_array('is_search', $checks));
-  echo '><label for="'.$id.'">' . __( '検索結果一覧', THEME_NAME ) . '</label></li>';
-
-  $id = $name.'_'.'is_404';
-  echo '<li><input type="checkbox" name="'.$name.'[]" value="is_404" id="'.$id.'" ';
-  checked(in_array('is_404', $checks));
-  echo '><label for="'.$id.'">' . __( '404ページ', THEME_NAME ) . '</label></li>';
-
-  if (is_amp_enable()) {
-    $id = $name.'_'.'is_amp';
-    echo '<li><input type="checkbox" name="'.$name.'[]" value="is_amp" id="'.$id.'" ';
-    checked(in_array('is_amp', $checks));
-    echo '><label for="'.$id.'">' . __( 'AMPページ', THEME_NAME ) . '</label></li>';
-  }
-
-  if (is_wpforo_exist()) {
-    $id = $name.'_'.'is_wpforo_plugin_page';
-    echo '<li><input type="checkbox" name="'.$name.'[]" value="is_wpforo_plugin_page" id="'.$id.'" ';
-    checked(in_array('is_wpforo_plugin_page', $checks));
-    echo '><label for="'.$id.'">' . __( 'wpForoページ', THEME_NAME ) . '</label></li>';
-  }
-
-  if (is_bbpress_exist()) {
-    $id = $name.'_'.'is_bbpress_page';
-    echo '<li><input type="checkbox" name="'.$name.'[]" value="is_bbpress_page" id="'.$id.'" ';
-    checked(in_array('is_bbpress_page', $checks));
-    echo '><label for="'.$id.'">' . __( 'bbPressページ', THEME_NAME ) . '</label></li>';
-  }
-
-  if (is_buddypress_exist()) {
-    $id = $name.'_'.'is_buddypress_page';
-    echo '<li><input type="checkbox" name="'.$name.'[]" value="is_buddypress_page" id="'.$id.'" ';
-    checked(in_array('is_buddypress_page', $checks));
-    echo '><label for="'.$id.'">' . __( 'BuddyPressページ', THEME_NAME ) . '</label></li>';
-  }
-
-  if (is_plugin_fourm_exist()) {
-    $id = $name.'_'.'is_plugin_fourm_page';
-    echo '<li><input type="checkbox" name="'.$name.'[]" value="is_plugin_fourm_page" id="'.$id.'" ';
-    checked(in_array('is_plugin_fourm_page', $checks));
-    echo '><label for="'.$id.'">' . __( 'プラグインフォーラムページ（bbPress、BuddyPress、wpForo）', THEME_NAME ) . '</label></li>';
+  foreach ( $page_types as $value => $label ) {
+    $id = $name . '_' . $value;
+    echo '<li>';
+    echo '<input type="checkbox" name="' . esc_attr($name) . '[]" value="' . esc_attr($value) . '" id="' . esc_attr($id) . '" ';
+    checked( in_array( $value, $checks, true ) );
+    echo '><label for="' . esc_attr($id) . '">' . esc_html($label) . '</label>';
+    echo '</li>';
   }
 
   echo '</ul></div>';

--- a/lib/html-forms.php
+++ b/lib/html-forms.php
@@ -826,7 +826,7 @@ function generate_page_display_check_list( $name, $checks, $width = 0 ) {
     $page_types['is_plugin_fourm_page'] = __( 'プラグインフォーラムページ（bbPress、BuddyPress、wpForo）', THEME_NAME );
   }
 
-  echo '<div class="tab-content page-display-check-list ' . esc_attr($name) . '-list" style="width:' . esc_attr($width) . ';">';
+  echo '<div class="tab-content page-display-check-list ' . esc_attr($name) . '-list" style="width: ' . esc_attr($width) . ';">';
   echo '<ul>';
 
   foreach ( $page_types as $value => $label ) {


### PR DESCRIPTION
# 本PRの目的

ウィジェットのページ表示チェックリストのコードをリファクタリングできればと思います。

# 対象フォーラム

[ウィジェットの表示設定のページリスト表示のソースについて](https://wp-cocoon.com/community/cocoon-theme/%e3%82%a6%e3%82%a3%e3%82%b8%e3%82%a7%e3%83%83%e3%83%88%e3%81%ae%e8%a1%a8%e7%a4%ba%e8%a8%ad%e5%ae%9a%e3%81%ae%e3%83%9a%e3%83%bc%e3%82%b8%e3%83%aa%e3%82%b9%e3%83%88%e8%a1%a8%e7%a4%ba%e3%81%ae%e3%82%bd/)

# 対応内容

- lib\html-forms.phpのgenerate_page_display_check_list()関数内のコードを可読性・保守性をあげるためのリファクタリング対応

# 調整イメージ

![スクリーンショット 2025-10-28 094113](https://github.com/user-attachments/assets/f0bbd70f-6365-49de-a324-3248368958e0)

# 動作確認

以下すべてのパターンで動作の方確認いたしました。

■ ウィジェットの表示「チェック・入力したページで非表示にする」の場合

- カテゴリー
- ページ
- 投稿者（投稿者ページのみ引き続き確認）
- 投稿
- 固定ページ
- タグ
- カスタム投稿タイプ

■ ウィジェットの表示「チェック・入力したページで表示する」の場合

- カテゴリー
- ページ
- 投稿者
- 投稿
- 固定ページ
- タグ
- カスタム投稿タイプ