### PR TITLE
feat(util): unify cdn usage for jquery

### DIFF
--- a/lib/utils.php
+++ b/lib/utils.php
@@ -518,13 +518,13 @@ function get_jquery_core_url($ver){
   $url = null;
   switch ($ver) {
     case '3':
-      $url = 'https://ajax.googleapis.com/ajax/libs/jquery/3.6.1/jquery.min.js';
+      $url = 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.1/jquery.min.js';
       break;
     case '2':
-      $url = 'https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js';
+      $url = 'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js';
       break;
     case '1':
-      $url = 'https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js';
+      $url = 'https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js';
       break;
   }
   return $url;


### PR DESCRIPTION
I want to unify the cdn usage for jquery. I searched the code base, seems [googleapi is only used for fonts](https://github.com/search?q=repo%3Axserver-inc%2Fcocoon%20googleapi&type=code).

considering even jquery-migrate is using CDN urls provided by Cloudflare, it's more reasonable to unify the same for jquery.

https://github.com/xserver-inc/cocoon/blob/8fa4f71746e236d2570af2ff4293a5e28cccd214/lib/utils.php#L554-L567