### PR TITLE
「本文全ての目次を表示する」設定がオンの場合でも、ショートコードで追加した見出しが目次に正しく表示されるように調整

### DIFF
--- a/lib/toc.php
+++ b/lib/toc.php
@@ -57,6 +57,7 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
       }
       // パターン展開（同期パターン）
       $page_content = expand_synced_patterns($page_content);
+      $page_content = do_shortcode($page_content);
       $pages[] = $page_content;
     }
   }


### PR DESCRIPTION
# 本PRの目的

ページ区切りブロックでページを分割し、Cocoon設定「目次」の「本文全ての目次を表示する」をONにした場合に通常の見出しはすべて目次に表示されるが、add_shortcode()関数で自作した見出しを表示するショートコードだと表示されないため、調整できればと思います。

「本文全ての目次を表示する」をOFFにした時はショートコードの見出しは目次に表示されていたため、合わせる形で調整。

# 対象フォーラム

[ショートコードで追加した見出しが目次に反映されない](https://wp-cocoon.com/community/bugs/%e3%82%b7%e3%83%a7%e3%83%bc%e3%83%88%e3%82%b3%e3%83%bc%e3%83%89%e3%81%a7%e8%bf%bd%e5%8a%a0%e3%81%97%e3%81%9f%e8%a6%8b%e5%87%ba%e3%81%97%e3%81%8c%e7%9b%ae%e6%ac%a1%e3%81%ab%e5%8f%8d%e6%98%a0%e3%81%95/)

# 対応内容

- lib\toc.phpの60行目付近にdo_shortcode()関数での処理を追加し、ショートコードでの出力を追加

# 不具合再現方法

まず以下のコードをfunctions.phpにコピペします。

```
add_shortcode('h2_shortcode', function() {
    return '<h2>h2のショートコード見出し</h2>';
});

add_shortcode('h3_shortcode', function() {
    return '<h3>h3のショートコード見出し</h3>';
});

add_shortcode('h4_shortcode', function() {
    return '<h4>h4のショートコード見出し</h4>';
});

add_shortcode('h5_shortcode', function() {
    return '<h5>h5のショートコード見出し</h5>';
});

add_shortcode('h6_shortcode', function() {
    return '<h6>h6のショートコード見出し</h6>';
});
```

上記で追加したショートコードをエディタに追加します。

![スクリーンショット 2025-12-02 121110](https://github.com/user-attachments/assets/779712f3-985d-4ce7-8a75-d934305ff324)

ページ区切りブロックを本文途中に追加します。

![スクリーンショット 2025-11-26 180913](https://github.com/user-attachments/assets/7b50e814-3f14-4bd9-ad7f-0cfbf99d24e2)

最後にCocoon設定「目次の」の「本文全ての目次を表示する」をONにします。

![スクリーンショット 2025-12-02 122725](https://github.com/user-attachments/assets/30cd12dc-9dbe-4cdf-826a-5503d9261fb6)

その結果、「本文全ての目次を表示する」をOFFとしていた場合はショートコードで追加した見出しが追加されていたが、ONとした場合にショートコードの見出しが消えてしまう事象が起こっているかと思います。

![スクリーンショット 2025-12-02 121437](https://github.com/user-attachments/assets/fa8e02ae-0f3a-43f4-a66b-6a9e5671d1a2)

# 原因

lib/toc.phpの以下の箇所にて、do_shortcode()関数にてショートコードを展開していないことが原因かと思われます。

https://github.com/xserver-inc/cocoon/blob/9966ab18ce7a8b7d70e013d3f0f432cab94f38f8/lib/toc.php#L55-L57

get_shortcode_removed_content()関数で特定のショートコートを除去、do_blocks()関数でGutenbergブロックを展開、expand_synced_patterns()関数で 同期パターンを展開の3つの処理を行っておりますが、ショートコードの展開の処理はありませんでした。

# 対策

上記3つの処理の後ろに、以下のコードを追加してショートコードを展開することで、本文中のショートコードの見出しを目次に反映することが可能となります。

`$page_content = do_shortcode($page_content);`

https://github.com/xs-stakazawa/cocoon/pull/4/files

# 修正後イメージ

対策後、「ページ区切りブロックを本文途中に追加」＋「ショートコードでの見出しを本文中に追加」とした場合でも、下図のようにショートコードで追加した見出しが表示され、挙動も問題なく機能していることも確認できました。

![スクリーンショット 2025-12-02 121840](https://github.com/user-attachments/assets/2c5a9b92-5add-4544-85ea-c70e752646f4)

# 動作確認

- [x] ショートコード見出しが正しく目次に追加されるか
- [x] 目次から見出しへのジャンプが機能するか
- [x] 分割ページ間のリンクが正しく動作するか
- [x] PHP警告やエラーが出ていないか
- [x] h2～h6でのショートコードでちゃんと機能するか
- [x] ブロック内に追加した見出しショートコードでの挙動も問題ないか
- [x] クラシックエディタでも問題なさそうか

以下検証に使用したコードになります。
以下functions.phpにコピペいただくことで作成されるショートコードのコードになります。

```
add_shortcode('h2_shortcode', function() {
    return '<h2>h2のショートコード見出し</h2>';
});

add_shortcode('h3_shortcode', function() {
    return '<h3>h3のショートコード見出し</h3>';
});

add_shortcode('h4_shortcode', function() {
    return '<h4>h4のショートコード見出し</h4>';
});

add_shortcode('h5_shortcode', function() {
    return '<h5>h5のショートコード見出し</h5>';
});

add_shortcode('h6_shortcode', function() {
    return '<h6>h6のショートコード見出し</h6>';
});
```

また、以下がエディタにて追加したサンプルコードになります。

```
<!-- wp:shortcode -->
[h2_shortcode]
<!-- /wp:shortcode -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:shortcode -->
[h3_shortcode]
<!-- /wp:shortcode -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:shortcode -->
[h4_shortcode]
<!-- /wp:shortcode -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:shortcode -->
[h5_shortcode]
<!-- /wp:shortcode -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:shortcode -->
[h6_shortcode]
<!-- /wp:shortcode -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:cocoon-blocks/icon-box -->
<div class="wp-block-cocoon-blocks-icon-box common-icon-box block-box information-box"><!-- wp:shortcode -->
[h2_shortcode]
<!-- /wp:shortcode --></div>
<!-- /wp:cocoon-blocks/icon-box -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2 class="wp-block-heading"><span style="color:red;">注目！</span>これはテストです</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2 class="wp-block-heading">これはテストです</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:nextpage -->
<!--nextpage-->
<!-- /wp:nextpage -->

<!-- wp:heading -->
<h2 class="wp-block-heading">これはテストです</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2 class="wp-block-heading">これはテストです</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:shortcode -->
[h2_shortcode]
<!-- /wp:shortcode -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:shortcode -->
[h3_shortcode]
<!-- /wp:shortcode -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:shortcode -->
[h4_shortcode]
<!-- /wp:shortcode -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:shortcode -->
[h5_shortcode]
<!-- /wp:shortcode -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:shortcode -->
[h6_shortcode]
<!-- /wp:shortcode -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:cocoon-blocks/icon-box -->
<div class="wp-block-cocoon-blocks-icon-box common-icon-box block-box information-box"><!-- wp:shortcode -->
[h2_shortcode]
<!-- /wp:shortcode --></div>
<!-- /wp:cocoon-blocks/icon-box -->

<!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph -->
```