### PR TITLE
「本文全ての目次を表示する」をONにした時に「表示条件」が効かなくなる挙動を調整

### DIFF
--- a/lib/toc.php
+++ b/lib/toc.php
@@ -100,6 +100,7 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
 
   if ($is_multi_page_toc_visible) {
     // 分割ページごとに見出しを取得
+    $toc_counter = 0;
     $page_num = 1;
     $past_page_num = 1;
     foreach ($pages as $page_content) {
@@ -108,7 +109,7 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
           // 違うページになったらカウンターをリセットする
           if ($page_num !== $past_page_num) {
             $past_page_num = $page_num;
-            $counter = 0;
+            $toc_counter = 0;
           }
 
           // 目次の深さ取得
@@ -116,11 +117,11 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
 
           // $set_depth より深い見出しは目次に追加しない
           if ($now_depth <= $set_depth) {
-            $counter++;
+            $toc_counter++;
             $headers[] = array(
               'tag'  => $m[1],
               'text' => $m[2],
-              'id'   => 'toc' . $counter,
+              'id'   => 'toc' . $toc_counter,
               'page' => $page_num,
             );
           }
@@ -252,9 +253,8 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
   </div>';
 
   global $_TOC_AVAILABLE_H_COUNT;
-  // 表示条件は本文中の全見出し数で判定（深さ制限で除外される見出しも含む）
-  $_TOC_AVAILABLE_H_COUNT = $header_count;
-  if (!is_toc_display_count_available($header_count)){
+  $_TOC_AVAILABLE_H_COUNT = $counter;
+  if (!is_toc_display_count_available($counter)){
     return ;
   }
 

--- a/lib/toc.php
+++ b/lib/toc.php
@@ -252,8 +252,9 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
   </div>';
 
   global $_TOC_AVAILABLE_H_COUNT;
-  $_TOC_AVAILABLE_H_COUNT = $counter;
-  if (!is_toc_display_count_available($counter)){
+  // 表示条件は本文中の全見出し数で判定（深さ制限で除外される見出しも含む）
+  $_TOC_AVAILABLE_H_COUNT = $header_count;
+  if (!is_toc_display_count_available($header_count)){
     return ;
   }
 


### PR DESCRIPTION
# 本PRの目的

「本文全ての目次を表示する」をONにした時に「表示条件」との挙動で不具合がみられたため、調整できればと思います。

確認できた挙動としては、「本文全ての目次を表示する」をONにした場合、「表示条件」に関係なく常時目次が表示されてしまう不具合になります。

例えば、本文中に見出しが3つあるとして、「表示条件」で「5つ以上見出しがあるとき」を設定した場合に、通常5つ以上とう条件を持たさないため、目次は非表示になるかと思いますが、表示されてしまう形になります。

# 対応状況

- [x] 実装
- [x] 動作テスト

# 対応内容

- lib\toc.phpのget_toc_tag()関数にて、「// 分割ページごとに見出しを取得」の処理の箇所の変数名を $counter から $toc_counter に変更

# 不具合再現方法

以下のコードをエディタにコピペします。（見出し3つ、段落3つのセットになります）

```
<!-- wp:heading -->
<h2 class="wp-block-heading">これはテストです</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2 class="wp-block-heading">これはテストです</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2 class="wp-block-heading">これはテストです</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->
```

コピペしていただくと、下図のように表示されます。

<img width="677" height="424" alt="スクリーンショット 2025-12-03 113717" src="https://github.com/user-attachments/assets/606711a8-bd9b-4330-b169-e99e75603057" />

下図のように「本文全ての目次を表示する」をONにしていただき、「表示条件」を「5」とします。

![スクリーンショット 2025-12-02 144710](https://github.com/user-attachments/assets/4f99a96e-40e0-4823-a52a-a38a5a72a815)

再度フロントをご確認いただくと、下図のように目次が表示されてしまう現象が確認できるかと思います。

<img width="419" height="204" alt="スクリーンショット 2025-12-17 125534" src="https://github.com/user-attachments/assets/83448661-c663-4512-bbb4-fac6ffc8c90d" />

# 原因

不具合の根本原因は、表示条件の判定に使用していた$counter変数が、分割ページモードにおいて最後のページの見出し数しか保持していなかったことにあるかと思います。

■ 問題のあったコード

lib\toc.php 254行目付近

```
$_TOC_AVAILABLE_H_COUNT = $counter;
if (!is_toc_display_count_available($counter)){
  return ;
}
```

$counter変数はページ遷移時にリセットされる仕様のため、最後のページの見出し数しか保持できません。
そのため、以下の対応をおこなうことが良いかと思います。

# 対策

変数名を $counter から $toc_counter に変更することで、分割ページごとに目次IDをリセットする仕組みを追加しました。

この対策により、分割ページ（<!--nextpage-->）を使用している記事で、各ページごとに独立した目次カウンターが機能します。

このように分離することで、それぞれの処理が独立して正しく動作します。

■ 修正後のコード

```
    // 分割ページごとに見出しを取得
    $toc_counter = 0;
    $page_num = 1;
    $past_page_num = 1;
    foreach ($pages as $page_content) {
      if (preg_match_all('/<([hH][1-6]).*?>(.*?)<\/[hH][1-6]>/us', $page_content, $matches, PREG_SET_ORDER)) {
        foreach ($matches as $m) {
          // 違うページになったらカウンターをリセットする
          if ($page_num !== $past_page_num) {
            $past_page_num = $page_num;
            $toc_counter = 0;
          }

          // 目次の深さ取得
          $now_depth = intval(substr(strtolower($m[1]), 1, 1));

          // $set_depth より深い見出しは目次に追加しない
          if ($now_depth <= $set_depth) {
            $toc_counter++;
            $headers[] = array(
              'tag'  => $m[1],
              'text' => $m[2],
              'id'   => 'toc' . $toc_counter,
              'page' => $page_num,
            );
          }
        }
      }
      $page_num++;
    }
    $header_count = count($headers);
```

# 動作確認

- 「表示条件」での確認
- 「目次表示の深さ」での確認
- 「表示条件」と「目次表示の深さ」でのかけ合わせでのすべてのパターンにて確認
- 「本文全ての目次を表示する」のON・OFF両方のパターンにて「表示条件」と「目次表示の深さ」のすべてのパターンにて確認
- ウィジェットに追加した目次ショートコードの挙動

# 調査メモ

$counter（目次に表示される見出し数）
$header_count（本文中の全見出し数）