### PR TITLE
スキン「SILK」の見出しCSS調整によるspanタグ追加処理の削除

### DIFF
--- a/lib/toc.php
+++ b/lib/toc.php
@@ -100,7 +100,6 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
 
   if ($is_multi_page_toc_visible) {
     // 分割ページごとに見出しを取得
-    $toc_counter = 0;
     $page_num = 1;
     $past_page_num = 1;
     foreach ($pages as $page_content) {
@@ -109,7 +108,7 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
           // 違うページになったらカウンターをリセットする
           if ($page_num !== $past_page_num) {
             $past_page_num = $page_num;
-            $toc_counter = 0;
+            $counter = 0;
           }
 
           // 目次の深さ取得
@@ -117,11 +116,11 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
 
           // $set_depth より深い見出しは目次に追加しない
           if ($now_depth <= $set_depth) {
-            $toc_counter++;
+            $counter++;
             $headers[] = array(
               'tag'  => $m[1],
               'text' => $m[2],
-              'id'   => 'toc' . $toc_counter,
+              'id'   => 'toc' . $counter,
               'page' => $page_num,
             );
           }

--- a/lib/toc.php
+++ b/lib/toc.php
@@ -100,6 +100,7 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
 
   if ($is_multi_page_toc_visible) {
     // 分割ページごとに見出しを取得
+    $toc_counter = 0;
     $page_num = 1;
     $past_page_num = 1;
     foreach ($pages as $page_content) {
@@ -108,7 +109,7 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
           // 違うページになったらカウンターをリセットする
           if ($page_num !== $past_page_num) {
             $past_page_num = $page_num;
-            $counter = 0;
+            $toc_counter = 0;
           }
 
           // 目次の深さ取得
@@ -116,11 +117,11 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
 
           // $set_depth より深い見出しは目次に追加しない
           if ($now_depth <= $set_depth) {
-            $counter++;
+            $toc_counter++;
             $headers[] = array(
               'tag'  => $m[1],
               'text' => $m[2],
-              'id'   => 'toc' . $counter,
+              'id'   => 'toc' . $toc_counter,
               'page' => $page_num,
             );
           }
@@ -252,9 +253,8 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
   </div>';
 
   global $_TOC_AVAILABLE_H_COUNT;
-  // 表示条件は本文中の全見出し数で判定（深さ制限で除外される見出しも含む）
-  $_TOC_AVAILABLE_H_COUNT = $header_count;
-  if (!is_toc_display_count_available($header_count)){
+  $_TOC_AVAILABLE_H_COUNT = $counter;
+  if (!is_toc_display_count_available($counter)){
     return ;
   }
 

--- a/lib/toc.php
+++ b/lib/toc.php
@@ -252,8 +252,9 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
   </div>';
 
   global $_TOC_AVAILABLE_H_COUNT;
-  $_TOC_AVAILABLE_H_COUNT = $counter;
-  if (!is_toc_display_count_available($counter)){
+  // 表示条件は本文中の全見出し数で判定（深さ制限で除外される見出しも含む）
+  $_TOC_AVAILABLE_H_COUNT = $header_count;
+  if (!is_toc_display_count_available($header_count)){
     return ;
   }
 

--- a/skins/silk/functions.php
+++ b/skins/silk/functions.php
@@ -200,7 +200,6 @@ class Skin_Silk_Functions {
     add_action('admin_menu', [$this, 'reusable_menu']);
     add_filter('image_size_names_choose', [$this, 'image_size']);
     add_action('init', [$this, 'block_pattern']);
-    add_filter('render_block_core/heading', [$this, 'blocks_heading'], 10, 2);
     add_filter('render_block_core/group', [$this, 'blocks_group'], 10, 2);
     add_filter('render_block_cocoon-blocks/toggle-box-1', [$this, 'blocks_toggle'], 10, 2);
     add_filter('render_block_cocoon-blocks/faq', [$this, 'blocks_faq'], 10, 2);
@@ -1071,13 +1070,6 @@ class Skin_Silk_Functions {
     if (function_exists('register_block_pattern_category')) {
       register_block_pattern_category('silk', ['label' => 'Cocoonスキン「SILK」']);
     }
-  }
-
-  //見出しブロック
-  public function blocks_heading($content, $block) {
-    $level   = array_key_exists('level', $block['attrs']) ? 'h'.strval($block['attrs']['level']) : 'h2';
-    $content = preg_replace('/<'.$level.'(.*?)>(.*?)<\/'.$level.'>/', '<'.$level.'$1><span>$2</span></'.$level.'>', $content);
-    return $content;
   }
 
   //グループブロック


### PR DESCRIPTION
# 本PRの目的

先日おこなったスキン「SILK」の以下の対策後、関連する不要と思われるコードが残っているため削除できればと思います。

https://github.com/xserver-inc/cocoon/pull/292

# 対応状況

- [x] 実装
- [x] 動作テスト

# 対応内容

- skins/silk/functions.phpにて、以前見出しに追加されていたspanタグに対するCSS適用せず依存させない調整による、不要になったコードを削除

# 対象フォーラム

[スキン「SILK」の改善について](https://wp-cocoon.com/community/skin-bugs/%e3%82%b9%e3%82%ad%e3%83%b3%e3%80%8csilk%e3%80%8d%e3%81%ae%e6%94%b9%e5%96%84%e3%81%ab%e3%81%a4%e3%81%84%e3%81%a6/)

# 調整後イメージ

もともとは下図のようにh2～h6すべての見出しタグにspanタグを追加する処理が加えられておりました。（図はh3の例です）

![スクリーンショット 2025-12-26 170316](https://github.com/user-attachments/assets/0e1eedcc-81b2-4fe7-aea6-7c0a01e0c128)

本PRにて調整後、下図のようにspanタグが追加されないように調整されます。

<img width="185" height="77" alt="スクリーンショット 2025-12-26 170358" src="https://github.com/user-attachments/assets/488b0aaa-1ec6-489f-800a-d678827d2d16" />

こちらのspanタグを追加させていた意図としては、デザインを柔軟に調整できるようにとのことと思われますが、先日行った[こちらのPR](https://github.com/xserver-inc/cocoon/pull/292)にて、spanタグの有無に依存しない形でCSS調整をおこなったため、一部コードが不要となりました。

以下の箇所のコードが不要と思われるコードとなります。

https://github.com/xserver-inc/cocoon/blob/2dea85c7e3be9c45c73cefa9fd9dafd05433dee5/skins/silk/functions.php#L203

https://github.com/xserver-inc/cocoon/blob/2dea85c7e3be9c45c73cefa9fd9dafd05433dee5/skins/silk/functions.php#L1076-L1081

# 動作テスト

以下それぞれのパターンで確認しましたが、表示に問題ありませんでした。

- ブロックエディタの場合
- ブロックエディタでCocoon設定のサイトキーカラーを変更した場合
- クラシックエディタの場合
- クラシックエディタでCocoon設定のサイトキーカラーを変更した場合
- カウンターの動作
- キーカラーを変更した時
- Font Awesomeをver4、ver5で確認

■ フロント表示

<img width="322" height="304" alt="スクリーンショット 2025-12-26 191703" src="https://github.com/user-attachments/assets/11c9511d-dcc0-4421-9e1b-1d5aa4c725ca" />

（サイトキーカラー設定）

<img width="320" height="302" alt="スクリーンショット 2025-12-26 192324" src="https://github.com/user-attachments/assets/0be9a038-ee37-4050-97a5-ccf8aca9b702" />

■ エディタ表示

<img width="217" height="208" alt="スクリーンショット 2025-12-26 191727" src="https://github.com/user-attachments/assets/38715578-c1cb-431b-abdb-f0fe8c19101a" />

（サイトキーカラー設定）

<img width="331" height="315" alt="スクリーンショット 2025-12-26 192337" src="https://github.com/user-attachments/assets/1a61499f-2734-47e9-9f92-f05283f69813" />
