### PR TITLE
Cocoon設定「本文」の「noopener」を「noreferrer」に調整

### DIFF
--- a/lib/page-settings/content-forms.php
+++ b/lib/page-settings/content-forms.php
@@ -119,7 +119,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
             generate_tips_tag(__( 'rel属性にnoreferrerを追加します。', THEME_NAME ));?>
             <div class="indent<?php echo get_not_allowed_form_class(!is_external_link_noreferrer_enable(), true); ?>">
               <?php
-              generate_checkbox_tag(OP_EXTERNAL_TARGET_BLANK_LINK_NOREFERRER_ENABLE, is_external_target_blank_link_noreferrer_enable(), __( 'target="_blank"の際はnoopenerを追加する', THEME_NAME ));
+              generate_checkbox_tag(OP_EXTERNAL_TARGET_BLANK_LINK_NOREFERRER_ENABLE, is_external_target_blank_link_noreferrer_enable(), __( 'target="_blank"の際はnoreferrerを追加する', THEME_NAME ));
               generate_tips_tag(__( '新しいタブで開くリンクのrel属性にnoreferrerを追加します。', THEME_NAME ));
               ?>
             </div>
@@ -243,7 +243,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
             ?>
             <div class="indent<?php echo get_not_allowed_form_class(!is_internal_link_noreferrer_enable(), true); ?>">
               <?php
-              generate_checkbox_tag(OP_INTERNAL_TARGET_BLANK_LINK_NOREFERRER_ENABLE, is_internal_target_blank_link_noreferrer_enable(), __( 'target="_blank"の際はnoopenerを追加する', THEME_NAME ));
+              generate_checkbox_tag(OP_INTERNAL_TARGET_BLANK_LINK_NOREFERRER_ENABLE, is_internal_target_blank_link_noreferrer_enable(), __( 'target="_blank"の際はnoreferrerを追加する', THEME_NAME ));
               generate_tips_tag(__( '新しいタブで開くリンクのrel属性にnoreferrerを追加します。', THEME_NAME ));
               ?>
             </div>


### PR DESCRIPTION
年末年始ですので、お手すきでご確認いただけましたら幸いです🙇

# 本PRの目的

Cocoon設定「本文」の「外部リンク設定」と「内部リンク設定」のそれぞれの「追加rel属性」において、「noreferrerを追加する」の「target="_blank"の際はnoopenerを追加する」の「noopener」を「noreferrer」に文言調整できればと思います。

# 対応内容

- Cocoon設定「本文」の「外部リンク設定」と「内部リンク設定」のそれぞれの「target="_blank"の際はnoopenerを追加する」の「noopener」を「noreferrer」へ文言調整

# 対応状況

- [x] 調整
- [x] 動作テスト

# issues

[「Cocoon設定」－「本文」－「追加rel属性」](https://wp-cocoon.com/community/typos/%e3%80%8ccocoon%e8%a8%ad%e5%ae%9a%e3%80%8d%ef%bc%8d%e3%80%8c%e6%9c%ac%e6%96%87%e3%80%8d%ef%bc%8d%e3%80%8c%e8%bf%bd%e5%8a%a0rel%e5%b1%9e%e6%80%a7%e3%80%8d/)

# 調整後イメージ

![スクリーンショット 2025-12-29 194150](https://github.com/user-attachments/assets/f871a69a-4eb1-4c09-9800-f09e6f501ae8)

# 動作テスト

Cocoon設定「本文」の「外部リンク設定」「内部リンク設定」の「target="_blank"の際はnoreferrerを追加する」の動作確認＋周辺設定と掛け合わせた複数パターンにて確認

動作の方問題ありませんでした。

<img width="448" height="314" alt="スクリーンショット 2025-12-30 232601" src="https://github.com/user-attachments/assets/6520cce0-addf-44e8-97c3-f27f690f2f76" />
