### PR TITLE
外部ブログカード有効時、楽天商品ページの OGP 取得に失敗する問題を修正

### DIFF
--- a/lib/blogcard-out.php
+++ b/lib/blogcard-out.php
@@ -48,10 +48,15 @@ function url_to_external_blog_card($the_content) {
 
     //ブログカード化しないURLで除外
     $exclude_urls = apply_filters('exclusion_external_blog_card_urls', array());
+    $is_excluded = false;
     foreach ($exclude_urls as $exclude_url) {
       if (includes_string($url, $exclude_url)) {
-        return $match;
+        $is_excluded = true;
+        break;
       }
+    }
+    if ($is_excluded) {
+      continue;
     }
 
     $tag = url_to_external_blog_card_tag($url);

--- a/lib/open-graph.php
+++ b/lib/open-graph.php
@@ -14,7 +14,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-	Original can be found at https://github.com/scottmac/opengraph/blob/master/OpenGraph.php
+  Original can be found at https://github.com/scottmac/opengraph/blob/master/OpenGraph.php
 
 */
 
@@ -33,22 +33,22 @@ class OpenGraphGetter implements Iterator
    * a map so that the schema can be obtained
    *
    */
-	public static $TYPES = array(
-		'activity' => array('activity', 'sport'),
-		'business' => array('bar', 'company', 'cafe', 'hotel', 'restaurant'),
-		'group' => array('cause', 'sports_league', 'sports_team'),
-		'organization' => array('band', 'government', 'non_profit', 'school', 'university'),
-		'person' => array('actor', 'athlete', 'author', 'director', 'musician', 'politician', 'public_figure'),
-		'place' => array('city', 'country', 'landmark', 'state_province'),
-		'product' => array('album', 'book', 'drink', 'food', 'game', 'movie', 'product', 'song', 'tv_show'),
-		'website' => array('blog', 'website'),
-	);
+  public static $TYPES = array(
+    'activity' => array('activity', 'sport'),
+    'business' => array('bar', 'company', 'cafe', 'hotel', 'restaurant'),
+    'group' => array('cause', 'sports_league', 'sports_team'),
+    'organization' => array('band', 'government', 'non_profit', 'school', 'university'),
+    'person' => array('actor', 'athlete', 'author', 'director', 'musician', 'politician', 'public_figure'),
+    'place' => array('city', 'country', 'landmark', 'state_province'),
+    'product' => array('album', 'book', 'drink', 'food', 'game', 'movie', 'product', 'song', 'tv_show'),
+    'website' => array('blog', 'website'),
+  );
 
   /**
    * Holds all the Open Graph values we've parsed from a page
    *
    */
-	private $_values = array();
+  private $_values = array();
 
   /**
    * Fetches a URI and parses it for Open Graph data, returns
@@ -57,7 +57,7 @@ class OpenGraphGetter implements Iterator
    * @param $URI    URI to page to parse for Open Graph data
    * @return OpenGraphGetter
    */
-	static public function fetch($URI) {
+  static public function fetch($URI) {
     // wp_remote_get() の第2引数 args に渡すパラメータを組み立てる
     $args = array(
       'cocoon' => true,
@@ -118,7 +118,7 @@ class OpenGraphGetter implements Iterator
     } else {
         return false;
     }
-	}
+  }
 
   /**
    * Parses HTML and extracts Open Graph data, this assumes
@@ -127,10 +127,10 @@ class OpenGraphGetter implements Iterator
    * @param $HTML    HTML to parse
    * @return OpenGraphGetter
    */
-	static private function _parse($HTML, $URI = null) {
-		$old_libxml_error = libxml_use_internal_errors(true);
+  static private function _parse($HTML, $URI = null) {
+    $old_libxml_error = libxml_use_internal_errors(true);
 
-		$doc = new DOMDocument();
+    $doc = new DOMDocument();
     // //UTF-8ページの文字化け問題
     // //対処法1：http://qiita.com/kobake@github/items/3c5d09f9584a8786339d
     // //対処法2：http://nplll.com/archives/2011/06/_domdocumentloadhtml.php
@@ -143,7 +143,7 @@ class OpenGraphGetter implements Iterator
     if (!$HTML) {
       return false;
     }
-		$doc->loadHTML($HTML);
+    $doc->loadHTML($HTML);
 
     //タイトルタグからタイトル情報を取得
     preg_match( "/<title>(.*?)<\/title>/i", $HTML, $matches);
@@ -156,41 +156,41 @@ class OpenGraphGetter implements Iterator
       $description = $matches ? $matches[1] : null;
     }
 
-		libxml_use_internal_errors($old_libxml_error);
+    libxml_use_internal_errors($old_libxml_error);
 
-		$tags = $doc->getElementsByTagName('meta');
+    $tags = $doc->getElementsByTagName('meta');
 
-		if ((!$tags || $tags->length === 0) && !$title) {
-			return false;
-		}
+    if ((!$tags || $tags->length === 0) && !$title) {
+      return false;
+    }
 
-		$page = new self();
+    $page = new self();
     $page->_values['title'] = $title;
 
-		$nonOgDescription = null;
+    $nonOgDescription = null;
 
-		foreach ($tags AS $tag) {
-			if ($tag->hasAttribute('property') &&
-			    strpos($tag->getAttribute('property'), 'og:') === 0) {
-				$key = strtr(substr($tag->getAttribute('property'), 3), '-', '_');
-				$page->_values[$key] = $tag->getAttribute('content');
-			}
+    foreach ($tags AS $tag) {
+      if ($tag->hasAttribute('property') &&
+          strpos($tag->getAttribute('property'), 'og:') === 0) {
+        $key = strtr(substr($tag->getAttribute('property'), 3), '-', '_');
+        $page->_values[$key] = $tag->getAttribute('content');
+      }
 
-			//Added this if loop to retrieve description values from sites like the New York Times who have malformed it.
-			if ($tag ->hasAttribute('value') && $tag->hasAttribute('property') &&
-			    strpos($tag->getAttribute('property'), 'og:') === 0) {
-				$key = strtr(substr($tag->getAttribute('property'), 3), '-', '_');
-				$page->_values[$key] = $tag->getAttribute('value');
-			}
-			//Based on modifications at https://github.com/bashofmann/opengraph/blob/master/src/OpenGraph/OpenGraph.php
-			if ($tag->hasAttribute('name') && $tag->getAttribute('name') === 'description') {
+      //Added this if loop to retrieve description values from sites like the New York Times who have malformed it.
+      if ($tag ->hasAttribute('value') && $tag->hasAttribute('property') &&
+          strpos($tag->getAttribute('property'), 'og:') === 0) {
+        $key = strtr(substr($tag->getAttribute('property'), 3), '-', '_');
+        $page->_values[$key] = $tag->getAttribute('value');
+      }
+      //Based on modifications at https://github.com/bashofmann/opengraph/blob/master/src/OpenGraph/OpenGraph.php
+      if ($tag->hasAttribute('name') && $tag->getAttribute('name') === 'description') {
                 $nonOgDescription = $tag->getAttribute('content');
             }
 
-		}
+    }
 
-		//Based on modifications at https://github.com/bashofmann/opengraph/blob/master/src/OpenGraph/OpenGraph.php
-		if (!isset($page->_values['title'])) {
+    //Based on modifications at https://github.com/bashofmann/opengraph/blob/master/src/OpenGraph/OpenGraph.php
+    if (!isset($page->_values['title'])) {
             $titles = $doc->getElementsByTagName('title');
             if ($titles->length > 0) {
                 $page->_values['title'] = $titles->item(0)->textContent;
@@ -218,7 +218,7 @@ class OpenGraphGetter implements Iterator
             }
         }
 
-		if (empty($page->_values)) { return false; }
+    if (empty($page->_values)) { return false; }
 
     //og:titleが空文字だったとき
     $page_title = null;
@@ -237,8 +237,8 @@ class OpenGraphGetter implements Iterator
       $page->_values['description'] = $description;
     }
 
-		return $page;
-	}
+    return $page;
+  }
 
   /**
    * Helper method to access attributes directly
@@ -247,70 +247,70 @@ class OpenGraphGetter implements Iterator
    *
    * @param $key    Key to fetch from the lookup
    */
-	public function __get($key) {
-		if (array_key_exists($key, $this->_values)) {
-			return $this->_values[$key];
-		}
+  public function __get($key) {
+    if (array_key_exists($key, $this->_values)) {
+      return $this->_values[$key];
+    }
 
-		if ($key === 'schema') {
-			foreach (self::$TYPES AS $schema => $types) {
-				if (array_search($this->_values['type'], $types)) {
-					return $schema;
-				}
-			}
-		}
-	}
+    if ($key === 'schema') {
+      foreach (self::$TYPES AS $schema => $types) {
+        if (array_search($this->_values['type'], $types)) {
+          return $schema;
+        }
+      }
+    }
+  }
 
   /**
    * Return all the keys found on the page
    *
    * @return array
    */
-	public function keys() {
-		return array_keys($this->_values);
-	}
+  public function keys() {
+    return array_keys($this->_values);
+  }
 
   /**
    * Helper method to check an attribute exists
    *
    * @param $key
    */
-	public function __isset($key) {
-		return array_key_exists($key, $this->_values);
-	}
+  public function __isset($key) {
+    return array_key_exists($key, $this->_values);
+  }
 
   /**
    * Will return true if the page has location data embedded
    *
    * @return boolean Check if the page has location data
    */
-	public function hasLocation() {
-		if (array_key_exists('latitude', $this->_values) && array_key_exists('longitude', $this->_values)) {
-			return true;
-		}
+  public function hasLocation() {
+    if (array_key_exists('latitude', $this->_values) && array_key_exists('longitude', $this->_values)) {
+      return true;
+    }
 
-		$address_keys = array('street_address', 'locality', 'region', 'postal_code', 'country_name');
-		$valid_address = true;
-		foreach ($address_keys AS $key) {
-			$valid_address = ($valid_address && array_key_exists($key, $this->_values));
-		}
-		return $valid_address;
-	}
+    $address_keys = array('street_address', 'locality', 'region', 'postal_code', 'country_name');
+    $valid_address = true;
+    foreach ($address_keys AS $key) {
+      $valid_address = ($valid_address && array_key_exists($key, $this->_values));
+    }
+    return $valid_address;
+  }
 
   /**
    * Iterator code
    */
-	private $_position = 0;
+  private $_position = 0;
   #[\ReturnTypeWillChange]
-	public function rewind() { reset($this->_values); $this->_position = 0; }
+  public function rewind() { reset($this->_values); $this->_position = 0; }
   #[\ReturnTypeWillChange]
-	public function current() { return current($this->_values); }
+  public function current() { return current($this->_values); }
   #[\ReturnTypeWillChange]
-	public function key() { return key($this->_values); }
+  public function key() { return key($this->_values); }
   #[\ReturnTypeWillChange]
-	public function next() { next($this->_values); ++$this->_position; }
+  public function next() { next($this->_values); ++$this->_position; }
   #[\ReturnTypeWillChange]
-	public function valid() { return $this->_position < sizeof($this->_values); }
+  public function valid() { return $this->_position < sizeof($this->_values); }
 }
 
 //curlのバージョンチェック


### PR DESCRIPTION
@yhira (cc @xs-stakazawa)

いつも Cocoon テーマを使わせていただいております。約4年ぶりのプルリクエストとなります。
4年前、「楽天アフィリエイトのブログカードが表示されない」件で https://github.com/xserver-inc/cocoon/pull/61 にてプルリクエストを提出させていただいた者です。
その節はマージいただきありがとうございました。

## 発生していた問題

2025年12月頃から、私が運営しているブログで、[楽天アフィリエイトの URL を複数掲載している記事ページ](https://blog.tsukumijima.net/article/ts-dtv-tuner/) の読み込みが終わらない症状が発生しました。
私の環境では Apache の前段の nginx で 504 Gateway Timeout が発生し、ページ自体が表示できない状態に陥っていました。

## 原因

原因を切り分けていったところ、おそらく2025年12月頃から楽天商品ページのクローラー判定が強化され、ブラウザが送信する HTTP ヘッダーをほぼ完全に模倣しなければ、商品ページの HTML レスポンスの返却が10秒遅延させられるように変更されたことが判明しました。

OGP 取得時の HTTP アクセスに使われる `wp_remote_get()` のデフォルトタイムアウトは5秒のため、10秒遅延が発生している間にタイムアウトしてしまい、必ず OGP 取得が失敗する状態でした。
さらに、OGP 取得に失敗した URL はページロードのたびに再度 OGP 取得が走るため、楽天 URL を17個掲載していた記事では、5秒 × 17個 = 85秒以上のロード時間がかかっていました。
実際にサーバー内部から localhost の当該ページにリクエストを送ったところ、1分20〜30秒程度の遅延を確認しました。

過去に OGP 取得に失敗した URL でページロード時に毎回 OGP を取得しに行く挙動自体、表示速度の観点から改善の余地があるかと思いますが、おそらく DB スキーマ変更などを伴う大規模な変更になるため、今回は楽天商品ページのブログカードを正常に表示できるようにする方向で改善を行いました。

## 対策内容

- 楽天へのアクセス時のみ HTTP リクエストヘッダーを macOS Chrome に偽装し、クローラー判定を回避
- 今後偽装が効かなくなった場合に備え、楽天のみタイムアウトを15秒に延長し、OGP 取得を確実に成功させてキャッシュを効かせる

## 副次的な修正

デバッグ時に `exclusion_external_blog_card_urls` フィルターフックを使って原因の URL を切り分けようとしたところ、「パターンに一致した URL をブログカード化対象から除外する」ではなく「パターンに一致した URL のみを記事本文表示する」という明らかに壊れた挙動になっていたため、これを修正しました。

また、open-graph.php のインデントがタブ文字になっていたため、他のファイルに合わせてスペース2つに統一しました。

## 時系列まとめ

- 従来から、楽天の商品ページは機械的なアクセスに対して、意図的に10秒以上待機してからレスポンスを返す挙動になっていた（大量クロールによるアクセス過多対策…？）
- 2021年12月に、Accept-Language ヘッダーを付与すればクローラー判定を回避できることが判明し、https://github.com/xserver-inc/cocoon/pull/61 で修正
- 2025年12月頃から楽天側のクローラー判定が強化され、ブラウザが送信するほぼすべての HTTP ヘッダーを設定しない限り回避できなくなった
- 今回のコミットでは、楽天へのアクセス時のみ HTTP ヘッダーを macOS Chrome へ偽装し、また HTTP リクエストのタイムアウトを15秒に延長した

なお、調査の結果、クローラー判定は HTTP ヘッダーの組み合わせ・IP アドレス・TLS フィンガープリンティングなどを総合的にスコアリングしていると推測されます。

- 国内サーバー（ConoHa など）: accept-encoding 以外のヘッダーがあれば通過
- 海外大手クラウド（Oracle Cloud など）: accept-encoding ヘッダーも必須（= プレーンテキスト返却に非対応）

## 影響範囲

私は前回の調査知見から原因を推測できましたが（それでも解決までに数時間を要しました）、表面的には何が原因か分からない方が多いのではないかと思います。
楽天の商品リンクを WordPress サイトに掲載している方は相当数いるはずですし、他サイトにおいても、意図せず表示が極端に遅くなったり、最悪の場合はサーバー側でのタイムアウトで一切表示できなくなる問題が発生している可能性があります。

ぜひマージいただければ幸いです。よろしくお願いいたします。