### PR TITLE
スキン「てがきノート(ダークスカイ)」のアップデート(Version: 1.0.7.8)

### DIFF
--- a/skins/skin-tegakinote-dark-sky/style.css
+++ b/skins/skin-tegakinote-dark-sky/style.css
@@ -416,6 +416,13 @@ div:not(list-columns) .list:after {
 /************************
 * メニュー
 ************************/
+/* モバイルメニュー・サイドバーメニュー内見出し・ウィジェット見出しの文字色 */
+.mobile-menu-buttons,
+.mobile-menu-buttons .menu-icon, .mobile-menu-buttons .menu-caption,
+.sidebar-menu-content .sidebar h3, .widget h2 {
+	color: rgba(var(--gray-color), 1);
+}
+
 .navi-in a {
 	transition: all .8s ease;
 	cursor: pointer;

--- a/skins/skin-tegakinote-dark-sky/style.css
+++ b/skins/skin-tegakinote-dark-sky/style.css
@@ -6,7 +6,7 @@
   Author: ゆうそうと
   Author URI: https://usort.jp/
   Screenshot URI: https://im-cocoon.net/wp-content/uploads/tegakinote-dark-sky.jpg
-  Version: 1.0.7.8
+  Version: 1.0.7.9
   Priority: 9140005000
 */
 


### PR DESCRIPTION
お世話になっております。
てがきノート（ダークスカイ）スキンについて、以下の修正を行いました。

## 変更の背景

本スキンでは `body` や多くの要素に `--gray-color` を用いた文字色を指定していますが、次の要素には明示的な `color` 指定がなく、親やテーマのデフォルトに依存していました。

- モバイルメニューボタン（`.mobile-menu-buttons` およびアイコン・キャプション）
- サイドバーメニュー（ドロワー）内の見出し（`.sidebar-menu-content .sidebar h3`）
- ウィジェット見出し（`.widget h2`）

その結果、ダークスカイのトーンに合わせたグレーではなく、見えにくい色で表示される場合があり、表示のばらつきが生じていました。これらにもスキン共通の `--gray-color` をあてることで、全体の見た目を統一することを目的に今回の変更を行いました。

## 変更内容

- **モバイルメニュー・サイドバーメニュー内見出し・ウィジェット見出しの文字色を統一**
  - `.mobile-menu-buttons`、`.mobile-menu-buttons .menu-icon`、`.mobile-menu-buttons .menu-caption`、`.sidebar-menu-content .sidebar h3`、`.widget h2` に `color: rgba(var(--gray-color), 1);` を追加しました。
  - スキンで定義している `--gray-color` がこれらの要素にも適用され、表示の一貫性が保たれるようになります。
- **バージョンを 1.0.7.8 → 1.0.7.9 に更新**

## 変更ファイル

- `skins/skin-tegakinote-dark-sky/style.css`

大変お手数ですが、ご確認のほどよろしくお願いいたします。
