### PR TITLE
モバイルボタンのコメントが処理とあっていないためテキストを調整

### DIFF
--- a/tmp/mobile-comments-button.php
+++ b/tmp/mobile-comments-button.php
@@ -1,4 +1,4 @@
-<?php //モバイル用の「次へ」ボタン
+<?php //モバイル用のコメントボタン
 /**
  * Cocoon WordPress Theme
  * @author: yhira

--- a/tmp/mobile-follow-button.php
+++ b/tmp/mobile-follow-button.php
@@ -1,4 +1,4 @@
-<?php //モバイル用の検索ボタン
+<?php //モバイル用のフォローボタン
 /**
  * Cocoon WordPress Theme
  * @author: yhira

--- a/tmp/mobile-logo-button.php
+++ b/tmp/mobile-logo-button.php
@@ -1,4 +1,4 @@
-<?php //モバイル用のホームボタン
+<?php //モバイル用のロゴボタン
 /**
  * Cocoon WordPress Theme
  * @author: yhira

--- a/tmp/mobile-share-button.php
+++ b/tmp/mobile-share-button.php
@@ -1,4 +1,4 @@
-<?php //モバイル用の検索ボタン
+<?php //モバイル用のシェアボタン
 /**
  * Cocoon WordPress Theme
  * @author: yhira

--- a/tmp/mobile-toc-button.php
+++ b/tmp/mobile-toc-button.php
@@ -1,4 +1,4 @@
-<?php //モバイル用のスライドインボタンメニューの表示
+<?php //モバイル用の目次ボタン
 /**
  * Cocoon WordPress Theme
  * @author: yhira

--- a/tmp/mobile-top-button.php
+++ b/tmp/mobile-top-button.php
@@ -1,4 +1,4 @@
-<?php //モバイル用のスライドインボタンメニューの表示
+<?php //モバイル用のトップボタン
 /**
  * Cocoon WordPress Theme
  * @author: yhira


### PR DESCRIPTION
# 本PRの目的

モバイルボタンでのカスタムメニューで「#○○」を指定することで項目を柔軟に制御できるPHPファイルのコメントアウトで意味の方が適切でなかったため、調整できればと思います。

# 対象フォーラム

[モバイルボタンのコメントが処理とあっていない](https://wp-cocoon.com/community/typos/rss%e3%82%b7%e3%83%a7%e3%83%bc%e3%83%88%e3%82%b3%e3%83%bc%e3%83%89%e3%81%aesite%e3%82%aa%e3%83%97%e3%82%b7%e3%83%a7%e3%83%b3%e3%81%ae%e8%a1%a8%e7%a4%ba%e4%be%8b%e3%83%9f%e3%82%b9/#post-88094)

# 対応内容

- モバイルボタン周りの機能のPHPファイル6点のコメントが処理とあっていないためテキストを調整

以下6点のコメントアウトを調整いたしました。

- tmp/mobile-comments-button.php
- tmp/mobile-follow-button.php
- tmp/mobile-logo-button.php
- tmp/mobile-share-button.php
- tmp/mobile-toc-button.php
- tmp/mobile-top-button.php

お忙しいところ恐縮ですが、お手すきでご確認のほど、よろしくお願いいたします。