### PR TITLE
Cocoon設定「本文」の「外部リンク設定」「内部リンク設定」の文言の調整

### DIFF
--- a/lib/page-settings/content-forms.php
+++ b/lib/page-settings/content-forms.php
@@ -58,8 +58,6 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
   <h2 class="hndle"><?php _e( '外部リンク設定', THEME_NAME ) ?></h2>
   <div class="inside">
 
-    <p><?php _e( '外部リンク動作の設定です。外部ブログカードをはじめ、ショートコードや各ウィジェットに出力されるリンクにも適用されます。', THEME_NAME ) ?></p>
-
     <table class="form-table">
       <tbody>
 
@@ -180,8 +178,6 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
 <div id="internal-link" class="postbox">
   <h2 class="hndle"><?php _e( '内部リンク設定', THEME_NAME ) ?></h2>
   <div class="inside">
-
-    <p><?php _e( '内部リンク動作の設定です。内部ブログカードをはじめ、ショートコードや各ウィジェットに出力されるリンクにも適用されます。', THEME_NAME ) ?></p>
 
     <table class="form-table">
       <tbody>

--- a/lib/page-settings/content-forms.php
+++ b/lib/page-settings/content-forms.php
@@ -58,7 +58,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
   <h2 class="hndle"><?php _e( '外部リンク設定', THEME_NAME ) ?></h2>
   <div class="inside">
 
-    <p><?php _e( '外部リンク動作の設定です。外部ブログカードにも適用されます。', THEME_NAME ) ?></p>
+    <p><?php _e( '外部リンク動作の設定です。外部リンクすべてに適用されます。', THEME_NAME ) ?></p>
 
     <table class="form-table">
       <tbody>
@@ -76,7 +76,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
               'self' => __( '同じタブで開く（_self）', THEME_NAME ),
             );
             generate_selectbox_tag(OP_EXTERNAL_LINK_OPEN_TYPE, $options, get_external_link_open_type());
-            generate_tips_tag(__( '本文内の外部リンクをどのように開くか。', THEME_NAME ));
+            generate_tips_tag(__( '外部リンクをどのように開くか。', THEME_NAME ));
             ?>
           </td>
         </tr>
@@ -94,7 +94,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
               'follow' => __( 'フォローする（follow）', THEME_NAME ),
             );
             generate_selectbox_tag(OP_EXTERNAL_LINK_FOLLOW_TYPE, $options, get_external_link_follow_type());
-            generate_tips_tag(__( '本文内の外部リンクのフォロー状態を設定します。', THEME_NAME ));
+            generate_tips_tag(__( '外部リンクのフォロー状態を設定します。', THEME_NAME ));
             ?>
           </td>
         </tr>
@@ -181,7 +181,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
   <h2 class="hndle"><?php _e( '内部リンク設定', THEME_NAME ) ?></h2>
   <div class="inside">
 
-    <p><?php _e( '内部リンク動作の設定です。内部ブログカードにも適用されます。', THEME_NAME ) ?></p>
+    <p><?php _e( '内部リンク動作の設定です。内部リンクすべてに適用されます。', THEME_NAME ) ?></p>
 
     <table class="form-table">
       <tbody>
@@ -199,7 +199,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
               'self' => __( '同じタブで開く（_self）', THEME_NAME ),
             );
             generate_selectbox_tag(OP_INTERNAL_LINK_OPEN_TYPE, $options, get_internal_link_open_type());
-            generate_tips_tag(__( '本文内の内部リンクをどのように開くか。', THEME_NAME ));
+            generate_tips_tag(__( '内部リンクをどのように開くか。', THEME_NAME ));
             ?>
           </td>
         </tr>
@@ -217,7 +217,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
               'follow' => __( 'フォローする（follow）', THEME_NAME ),
             );
             generate_selectbox_tag(OP_INTERNAL_LINK_FOLLOW_TYPE, $options, get_internal_link_follow_type());
-            generate_tips_tag(__( '本文内の内部リンクのフォロー状態を設定します。', THEME_NAME ));
+            generate_tips_tag(__( '内部リンクのフォロー状態を設定します。', THEME_NAME ));
             ?>
           </td>
         </tr>

--- a/lib/page-settings/content-forms.php
+++ b/lib/page-settings/content-forms.php
@@ -58,6 +58,8 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
   <h2 class="hndle"><?php _e( '外部リンク設定', THEME_NAME ) ?></h2>
   <div class="inside">
 
+    <p><?php _e( '外部リンク動作の設定です。', THEME_NAME ) ?></p>
+
     <table class="form-table">
       <tbody>
 
@@ -178,6 +180,8 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
 <div id="internal-link" class="postbox">
   <h2 class="hndle"><?php _e( '内部リンク設定', THEME_NAME ) ?></h2>
   <div class="inside">
+
+    <p><?php _e( '内部リンク動作の設定です。', THEME_NAME ) ?></p>
 
     <table class="form-table">
       <tbody>

--- a/lib/page-settings/content-forms.php
+++ b/lib/page-settings/content-forms.php
@@ -58,7 +58,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
   <h2 class="hndle"><?php _e( '外部リンク設定', THEME_NAME ) ?></h2>
   <div class="inside">
 
-    <p><?php _e( '外部リンク動作の設定です。外部リンクすべてに適用されます。', THEME_NAME ) ?></p>
+    <p><?php _e( '外部リンク動作の設定です。外部ブログカードをはじめ、ショートコードや各ウィジェットに出力されるリンクにも適用されます。', THEME_NAME ) ?></p>
 
     <table class="form-table">
       <tbody>
@@ -181,7 +181,7 @@ if ( !defined( 'ABSPATH' ) ) exit; ?>
   <h2 class="hndle"><?php _e( '内部リンク設定', THEME_NAME ) ?></h2>
   <div class="inside">
 
-    <p><?php _e( '内部リンク動作の設定です。内部リンクすべてに適用されます。', THEME_NAME ) ?></p>
+    <p><?php _e( '内部リンク動作の設定です。内部ブログカードをはじめ、ショートコードや各ウィジェットに出力されるリンクにも適用されます。', THEME_NAME ) ?></p>
 
     <table class="form-table">
       <tbody>


### PR DESCRIPTION
# 本PRの目的

Cocoon設定「本文」の「外部リンク設定」「内部リンク設定」の文言の調整を行えればと思います。
また合わせて、RSSショートコードのページ等、一部マニュアルに注記を追加できればと思います。

# 対象フォーラム

[RSSショートコードのtargetオプションが効かない](https://wp-cocoon.com/community/postid/88169/)

# 問題点

問題として、2点あるかと思います。

まず、RSSショートコードマニュアルページにて、RSSショートコードでtarget=_selfとしたときにtarget=_blankとなってしまい、外部リンクでページが開いてしまう挙動が見られるかと思います。
こちら原因としては、Cocoon設定「本文」の「外部リンク設定」が適用されるために起こる挙動かと思います。

![560914977-9aa1c2cb-4510-4f3a-b7f3-d4e79e758c2a](https://github.com/user-attachments/assets/faa66883-c6e8-4a2b-9a51-ddfc0aa17239)

もう一つは、Cocoon設定「本文」の「外部リンク設定」「内部リンク設定」の文言に関してですが、この機能は本文だけでなくウィジェットにも適用されるため、以下それぞれの箇所の文言を調整する必要があるかと思いました。

■ Cocoon設定「本文」の「外部リンク設定」

![スクリーンショット 2026-04-09 201726](https://github.com/user-attachments/assets/5d458264-9d4e-47bd-a8d7-8e70c50b38f0)

■ Cocoon設定「本文」の「内部リンク設定」

<img width="568" height="271" alt="スクリーンショット 2026-04-09 201746" src="https://github.com/user-attachments/assets/9cf67575-c57a-4f60-8cc9-79bdd5d55f8d" />

# 対応策

以下のように調整できればと思います。

- RSSマニュアル、およびウィジェットのマニュアルに注記を追加
- Cocoon設定「本文」の「外部リンク設定」と「内部リンク設定」の一部文言を削除し調整

# 調整後イメージ

## Cocoon設定「本文」の「外部リンク設定」

<img width="547" height="280" alt="スクリーンショット 2026-04-09 203654" src="https://github.com/user-attachments/assets/20cac334-ea0d-4662-ad79-53c9b6ad85db" />


## Cocoon設定「本文」の「内部リンク設定」

<img width="526" height="285" alt="スクリーンショット 2026-04-09 203706" src="https://github.com/user-attachments/assets/3f61dfda-70ea-4b0c-a1e1-3305bd8f9b26" />

## マニュアルの調整

今回の調整とあわせて、以下のようにマニュアルを調整できればと思います。
以下ご提案に関して絶対ではございませんので、もし調整が必要そうでしたら、お気軽にお申しつけください！

結論、以下2点のマニュアルの調整を行えればと思います。

### ①RSSショートコードのマニュアル

以下のページの以下の見出しの箇所にて、下図のように注記を追加できればと思います。

ページ名：
[RSS記事一覧を表示するショートコードの利用方法](https://wp-cocoon.com/rss-shortcode/)

追加場所：target
https://wp-cocoon.com/rss-shortcode/#toc9

<img width="734" height="110" alt="スクリーンショット 2026-04-09 205742" src="https://github.com/user-attachments/assets/06db125d-018c-44ec-b2bb-58c01aeb2004" />

### ②ウィジェットのマニュアル

以下のページの以下の見出しの箇所にて、下図のように注記を追加できればと思います。

ページ名：
[Cocoonデフォルトのウィジェット機能まとめ](https://wp-cocoon.com/default-widgets/)

追加場所：PC用テキスト
https://wp-cocoon.com/default-widgets/#toc4

<img width="735" height="141" alt="スクリーンショット 2026-04-10 192105" src="https://github.com/user-attachments/assets/4479256f-ee93-4bfe-92f9-00fcb59d2329" />

追加場所：プロフィール
https://wp-cocoon.com/default-widgets/#toc7

<img width="741" height="148" alt="スクリーンショット 2026-04-10 192127" src="https://github.com/user-attachments/assets/b37ad015-e55b-4d1b-a4a7-64a8e1e53bd8" />

追加場所：モバイル用テキスト
https://wp-cocoon.com/default-widgets/#toc8

<img width="738" height="143" alt="スクリーンショット 2026-04-10 192116" src="https://github.com/user-attachments/assets/e9c0cb0e-b1d2-4b1e-9e52-6437478d110c" />

# 動作テスト

以下ウィジェットの動作のほう確認できました。

以下の4点にて

- テキスト（PC用）
- テキスト（モバイル用）
- プロフィール
- カスタムHTML

いずれも、Cocoon設定「本文」の「外部リンク設定」と「内部リンク設定」の機能が優先されて書き換わることも確認いたしました。

以下はCocoon設定「本文」の影響なしでした。

- RSS
- CTA
- おすすめカード
- ナビカード
- ボックスメニュー
- ランキング
- 人気記事
- 広告
- 広告（PC）
- 広告（モバイル）
- 新着情報
- 最近のコメント
- おすすめカード
- ナビカード
- ボックスメニュー
- ランキング
- 人気記事
- 広告
- 広告（PC）
- 広告（モバイル）
- 新着情報
- 最近のコメント
