### PR TITLE
新着情報リストのid="info-list"を削除（ID属性が重複するため）

### DIFF
--- a/lib/html-forms.php
+++ b/lib/html-forms.php
@@ -1920,7 +1920,7 @@ function generate_info_list_tag($atts){
   $frame_class = ($frame ? ' is-style-frame-border' : '');
   $divider_class = ($divider ? ' is-style-divider-line' : '');
   if( $query->have_posts() ): ?>
-    <div id="info-list" class="info-list<?php echo $frame_class; ?><?php echo $divider_class; ?>">
+    <div class="info-list<?php echo $frame_class; ?><?php echo $divider_class; ?>">
       <?php if ($caption): ?>
         <div class="info-list-caption"><?php echo esc_html($caption); ?></div>
       <?php endif; ?>


### PR DESCRIPTION
# 本PRの目的

新着情報リストのID属性が重複するため、id="info-list"を削除出来ればと思います。

# 対象フォーラム

[新着情報リストのID属性固定によるHTMLバリデーションエラー](https://wp-cocoon.com/community/bugs/%e6%96%b0%e7%9d%80%e6%83%85%e5%a0%b1%e3%83%aa%e3%82%b9%e3%83%88%e3%81%aeid%e5%b1%9e%e6%80%a7%e5%9b%ba%e5%ae%9a%e3%81%ab%e3%82%88%e3%82%8bhtml%e3%83%90%e3%83%aa%e3%83%87%e3%83%bc%e3%82%b7%e3%83%a7/#post-88224)