### PR TITLE
通知URLの有無によって、通知エリアのnotice-area-wrapの出力がなくなったりしないように調整

### DIFF
--- a/tmp/notice.php
+++ b/tmp/notice.php
@@ -8,26 +8,25 @@
 if ( !defined( 'ABSPATH' ) ) exit;
 
 $msg = get_notice_area_message();
-if (is_notice_area_visible() && $msg && !is_amp() && apply_filters('notice_area_visible', true)):
-  $url = get_notice_area_url();
- ?>
+$visible = is_notice_area_visible() && $msg && !is_amp() && apply_filters('notice_area_visible', true);
 
-<?php //リンクの開始タグ
-if ($url):
+if ($visible):
+  $url = get_notice_area_url();
   $target = is_notice_link_target_blank() ? ' target="_blank" rel="noopener"' : '';
 ?>
 <div id="notice-area-wrap" class="notice-area-wrap">
-  <a href="<?php echo $url; ?>" id="notice-area-link" class="notice-area-link"<?php echo $target; ?>>
-  <?php endif ?>
+  <?php //リンクの開始タグ
+  if ($url): ?>
+    <a href="<?php echo $url; ?>" id="notice-area-link" class="notice-area-link"<?php echo $target; ?>>
+  <?php endif; ?>
 
-    <div id="notice-area" class="notice-area nt-<?php echo get_notice_type(); ?>">
-      <span class="notice-area-message"><?php echo $msg; ?></span>
-    </div>
+  <div id="notice-area" class="notice-area nt-<?php echo get_notice_type(); ?>">
+    <span class="notice-area-message"><?php echo $msg; ?></span>
+  </div>
 
   <?php //aリンクの閉じタグ
   if ($url): ?>
-  </a>
+    </a>
+  <?php endif; ?>
 </div>
-<?php endif ?>
-
-<?php endif ?>
+<?php endif; ?>


### PR DESCRIPTION
# 本PRの目的

Cocoon設定→通知→通知設定「通知URL」の有無により、通知エリアの親要素が変わるため、大元をnotice-area-wrapのままとなるように調整できればと思います。

# 対象の設定箇所

下図のように、Cocoon設定→通知→通知設定「通知URL」になります。

![スクリーンショット 2026-04-14 185911](https://github.com/user-attachments/assets/53f68346-a1b7-4b89-82c8-23039f4b5cda)

# 調整前のイメージ

■ 「通知URL」の設定がありの場合

![スクリーンショット 2026-04-14 190059](https://github.com/user-attachments/assets/efddde2f-9edc-43e1-bd8a-e22b99c85e19)

■ 「通知URL」の設定がなしの場合

★クラス名「notice-area-wrap」なしのdivの出力なしとなります

![スクリーンショット 2026-04-14 185755](https://github.com/user-attachments/assets/43f3a107-1c20-4b0c-a253-ba2a6aa04b4e)

# 調整後のイメージ

■ 「通知URL」の設定がありの場合

![スクリーンショット 2026-04-14 192345](https://github.com/user-attachments/assets/51723571-4d8a-4ef9-8eb3-fd0835112e87)

■ 「通知URL」の設定がなしの場合

★クラス名「notice-area-wrap」のdivが通知URLありの場合と同様に出力されるようにいたしました

![スクリーンショット 2026-04-14 192258](https://github.com/user-attachments/assets/0c621a71-bc76-4ecc-b109-a260ae26a139)

# 動作テスト

Cocoon設定→通知→通知設定において、各項目掛け合わせでの動作テストにおいて、問題ないことを確認いたしました。