### PR TITLE
ci: ソース変更時にPOTファイル生成を自動実行

### DIFF
--- a/.github/workflows/pot_generator.yml
+++ b/.github/workflows/pot_generator.yml
@@ -1,6 +1,24 @@
 name: Generate POT file
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
+    # wp i18n make-pot の --include 対象と揃える（languages/ を含めないことで自己再トリガーも防止）
+    paths:
+      - 'blocks/src/**'
+      - 'lib/**'
+      - 'tmp/**'
+      - 'skins/**'
+      - 'templates/**'
+      - '*.php'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pot-generator
+  cancel-in-progress: false
 
 jobs:
   WP_POT_Generator:
@@ -29,6 +47,7 @@ jobs:
         DIFF_COUNT=$(git diff --cached --numstat | wc -l)
         if [ $DIFF_COUNT -ne 0 ]; then
           git commit -m "POT Regenerated"
+          git pull --rebase
           git push
         fi
       env:


### PR DESCRIPTION
## 概要
手動起動（workflow_dispatch）のみだった POT 生成ワークフローを、翻訳対象ソースの master への push で自動実行するよう変更します。翻訳フロー自動化の第一段階で、ソース変更から翻訳テンプレート更新までを人手ゼロにします。

## 変更点
- `push` トリガー追加（paths: `blocks/src/**`, `lib/**`, `tmp/**`, `skins/**`, `templates/**`, `*.php` — make-pot の `--include` と同一）
- 手動起動（workflow_dispatch）は従来どおり利用可能
- `concurrency` による直列化、push 前の `git pull --rebase` 追加で連続 push 時の競合を防止
- `permissions: contents: write` を明示

## 安全性
- POT コミットが自身を再トリガーするループはなし（paths に `languages/` を含めない + `GITHUB_TOKEN` の push はワークフローを起動しない GitHub 仕様の二重防止）
- 外部サービスへの接続・新規 Secrets は一切不要（`GITHUB_TOKEN` のみで完結）