### PR TITLE
test: エントリーカード更新日表示のエッジケースをカバー

### DIFF
--- a/tests/Unit/UpdateFieldTest.php
+++ b/tests/Unit/UpdateFieldTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * lib/custom-fields/update-field.php のユニットテスト
+ *
+ * 「更新しない」(update_level=low) 選択時に post_modified が
+ * 不正な 0000-00-00 にならないことを検証します。
+ */
+
+namespace Cocoon\Tests\Unit;
+
+use Cocoon\Tests\TestCase;
+use Brain\Monkey\Functions;
+
+class UpdateFieldTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        require_once dirname(__DIR__, 2) . '/lib/custom-fields/update-field.php';
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_POST['update_level']);
+        parent::tearDown();
+    }
+
+    private function baseData(): array
+    {
+        return [
+            'post_status'       => 'publish',
+            'post_date'         => '2025-03-01 12:00:00',
+            'post_modified'     => '2025-03-01 12:00:00',
+            'post_modified_gmt' => '2025-03-01 03:00:00',
+        ];
+    }
+
+    public function test_更新しない選択でlast_modifiedが空なら更新日を投稿日にしDBを汚さない(): void
+    {
+        Functions\when('get_post_meta')->justReturn(''); // last_modified 未設定（初回投稿など）
+        Functions\when('get_gmt_from_date')->alias(fn($d) => $d . ' GMT');
+        Functions\when('add_post_meta')->justReturn(true);
+        Functions\when('update_post_meta')->justReturn(true);
+
+        $_POST['update_level'] = 'low';
+        $result = update_custom_insert_post_data($this->baseData(), ['ID' => 0]);
+
+        $this->assertSame('2025-03-01 12:00:00', $result['post_modified']);
+        $this->assertNotSame('', $result['post_modified']);
+    }
+
+    public function test_更新しない選択でlast_modifiedがあればその値に固定する(): void
+    {
+        Functions\when('get_post_meta')->justReturn('2024-01-01 00:00:00');
+        Functions\when('get_gmt_from_date')->alias(fn($d) => $d . ' GMT');
+        Functions\when('add_post_meta')->justReturn(true);
+        Functions\when('update_post_meta')->justReturn(true);
+
+        $_POST['update_level'] = 'low';
+        $result = update_custom_insert_post_data($this->baseData(), ['ID' => 123]);
+
+        $this->assertSame('2024-01-01 00:00:00', $result['post_modified']);
+    }
+}

--- a/tests/Unit/UtilsTest.php
+++ b/tests/Unit/UtilsTest.php
@@ -962,4 +962,69 @@ class UtilsTest extends TestCase
         $this->assertSame(456, cocoon_url_to_postid($url));
     }
 
+    // ========================================================================
+    // get_update_time()
+    // ========================================================================
+
+    /**
+     * get_update_time() は get_post_timestamp($post_id, 'date'|'modified') で
+     * 投稿日時・更新日時を Unix タイムスタンプとして取得する。
+     * 不正な日付では get_post_timestamp が false を返す状況を模擬できるよう、
+     * 引数 $field に応じて投稿日時・更新日時を返すスタブを差し込む。
+     */
+    private function stubPostTimestamps($ptime, $mtime): void
+    {
+        \Brain\Monkey\Functions\when('get_post_timestamp')->alias(
+            fn($post_id, $field = 'date') => $field === 'modified' ? $mtime : $ptime
+        );
+    }
+
+    public function test_get_update_time_更新日が投稿日より新しい日付なら更新日を返す(): void
+    {
+        $this->stubPostTimestamps(
+            strtotime('2025-01-01 00:00:00'),
+            strtotime('2025-02-01 00:00:00')
+        );
+
+        $this->assertSame('2025/02/01', get_update_time('Y/m/d'));
+    }
+
+    public function test_get_update_time_更新日と投稿日が同日ならnullを返す(): void
+    {
+        // 時刻は更新日が後だが年月日が同じ場合は更新日なしとする
+        $this->stubPostTimestamps(
+            strtotime('2025-01-01 10:00:00'),
+            strtotime('2025-01-01 15:00:00')
+        );
+
+        $this->assertNull(get_update_time('Y/m/d'));
+    }
+
+    public function test_get_update_time_更新日が投稿日より過去ならnullを返す(): void
+    {
+        // 日付逆転（予約投稿など）は更新日なしとする
+        $this->stubPostTimestamps(
+            strtotime('2025-02-01 00:00:00'),
+            strtotime('2025-01-01 00:00:00')
+        );
+
+        $this->assertNull(get_update_time('Y/m/d'));
+    }
+
+    public function test_get_update_time_更新日時が不正_空ならnullを返す(): void
+    {
+        // 不正な更新日では get_post_timestamp が false を返す（0000-00-00 相当）
+        $this->stubPostTimestamps(strtotime('2025-01-01 00:00:00'), false);
+
+        $this->assertNull(get_update_time('Y/m/d'));
+    }
+
+    public function test_get_update_time_投稿日時が不正_空ならnullを返す(): void
+    {
+        // 投稿日時が取得できない場合も更新日なしとする
+        $this->stubPostTimestamps(false, strtotime('2025-02-01 00:00:00'));
+
+        $this->assertNull(get_update_time('Y/m/d'));
+    }
+
 }


### PR DESCRIPTION
> **📝 更新**: 日付表示の不具合本体は `master` の `d9c3efcd0`（fix: 更新日不正値・日付逆転時の日付表示不整合を修正）で**別途修正・マージ済み**になりました。本 PR は当初 fix でしたが、`master` へ rebase して重複する修正コミットを落とし、**リグレッションを守るユニットテストの追加のみ**に変更しています。以下、当初の fix 説明は取り消し線で残します。

## 概要

~~エントリーカードで、設定や投稿の状態によって投稿日・更新日が **一切表示されなくなる** 不具合を修正します。~~
→ 上記のとおり、修正本体は `master` でマージ済み。本 PR はそのリグレッションテストを追加します。

## 現象

「投稿日を表示しない／更新日を表示する」設定のとき、更新パネルで「更新しない」を選んだ投稿などで、エントリーカードから日付が丸ごと消えます。

参考（フォーラム報告）: https://wp-cocoon.com/community/bugs/%e3%82%a8%e3%83%b3%e3%83%88%e3%83%aa%e3%83%bc%e3%82%ab%e3%83%bc%e3%83%89%e3%81%ab%e6%97%a5%e4%bb%98%e3%81%8c%e8%a1%a8%e7%a4%ba%e3%81%95%e3%82%8c%e3%81%aa%e3%81%84%e5%a0%b4%e5%90%88%e3%81%8c%e3%81%82/

## 原因

2つの要因の合わせ技です。

**1. `get_update_time()`（`lib/utils.php`）**

更新日 ≦ 投稿日（＝更新なし相当）のとき、本来 `null` を返すべきところで投稿日（真値）を返していました。このため呼び出し側（`tmp/entry-card.php` ほか）で:

- 投稿日フォールバック `!$update_time` が働かず投稿日が出ない
- 更新日ガード `get_the_time('U') < get_update_time('U')` も成立せず更新日も出ない

結果として日付が一切出力されません。人気記事ウィジェットや SEO メタの日付逆転（更新日 < 投稿日）でも同じ根が影響します。

**2. 「更新しない」保存処理（`lib/custom-fields/update-field.php`）**

`low` 分岐で `get_post_meta(..., 'last_modified', true)` は未設定時に空文字を返すのに `isset()` が常に真になり、`post_modified` に空文字を代入 → DB に `0000-00-00 00:00:00` が保存されていました（初回投稿など）。これが要因1の「更新日が不正」を誘発します。

## 修正

> ⚠️ この節の修正は `master` (`d9c3efcd0`) で実施済みのため、本 PR には含まれません（rebase 時に重複コミットを破棄）。

- ~~**`get_update_time()`**: 更新日が取得不可、または投稿日以前なら `null` を返す（doc コメントの契約どおり）。不正な更新日時もガード。全呼び出し元を確認し、いずれも `null` で投稿日フォールバックに正しく倒れることを確認。SEO メタの日付逆転も併せて解消。~~
- ~~**`update-field.php`**: `low` 分岐で `last_modified` が空なら投稿日を採用し、`0000-00-00` の混入と、末尾 `add_post_meta` の未定義値参照を防止。~~

（`master` の実装は `get_update_time()` を `get_post_timestamp()` ベースのタイムスタンプ比較に置き換え、不正値・日付逆転・同日を `null` に、`low` 保存は空の `last_modified` を投稿日にフォールバックする方針です。）

## テスト

本 PR で追加するもの:

- **`tests/Unit/UtilsTest.php`** — `get_update_time()` の境界ケース: 更新日が投稿日より新しければ更新日を返す／同日・日付逆転・投稿日または更新日が不正値のときは `null`。`master` の実装に合わせ `get_post_timestamp()` をスタブ。
- **`tests/Unit/UpdateFieldTest.php`** — 「更新しない」(`update_level=low`) 保存で、`last_modified` が空なら投稿日へフォールバックし `0000-00-00` を書き込まないこと／値があればその値に固定することを検証。

~~共有モック（`tests/wp-mock-functions.php`）の日付スタブを `$format` 尊重＋タイムスタンプ注入可能に改修。~~
→ `master` の `get_post_timestamp()` ベース実装では不要になったため取りやめ（共有モックは変更なし）。

~~修正前は該当3ケースが失敗（RED）、修正後は **ユニット全 1269 テスト・9787 アサーション パス**（PHP 8.5 / Brain\Monkey）。~~
→ 実行環境の都合でローカルでは phpunit を実行できていないため、テストのパスは CI での確認をお願いします。
